### PR TITLE
Update canary workflow to use minimal script

### DIFF
--- a/canary.yml
+++ b/canary.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Canary check (SigNoz API)
         shell: pwsh
         run: |
-          $script = "C:\otel\canary-check.ps1"
+          $script = "C:\otel\canary-check-min.ps1"
           if (-Not (Test-Path $script)) {
             Write-Error "Missing $script"; exit 1
           }
@@ -27,5 +27,5 @@ jobs:
       # - name: Canary check (ClickHouse fallback)
       #   shell: pwsh
       #   run: |
-      #     & "C:\otel\canary-check.ps1" -UseClickHouse -ClickHouseHttp "http://localhost:18123"
+      #     & "C:\otel\canary-check-min.ps1"
       #     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
## Summary
- update the canary workflow to call the existing `canary-check-min.ps1` script
- adjust the ClickHouse fallback example to reference the same script

## Testing
- not run (workflow file only)


------
https://chatgpt.com/codex/tasks/task_e_68cdd300614c832ab7798cc4a6f71a7a