### PR TITLE
Add health check path for collector configs

### DIFF
--- a/baseline/config.yaml
+++ b/baseline/config.yaml
@@ -4,6 +4,7 @@
 extensions:
   health_check:
     endpoint: 127.0.0.1:13134
+    path: /healthz
   file_storage:
     directory: C:\ProgramData\Otelcol\FileStorage
     timeout: 10s

--- a/config-hardened-plus.yaml
+++ b/config-hardened-plus.yaml
@@ -4,6 +4,7 @@
 extensions:
   health_check:
     endpoint: 127.0.0.1:13134
+    path: /healthz
   file_storage:
     directory: C:\ProgramData\Otelcol\FileStorage
     timeout: 10s

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,7 @@
 extensions:
   health_check:
     endpoint: 127.0.0.1:13134
+    path: /healthz
   file_storage:
     directory: C:\ProgramData\Otelcol\FileStorage
     timeout: 10s

--- a/config.yaml.backup
+++ b/config.yaml.backup
@@ -4,6 +4,7 @@
 extensions:
   health_check:
     endpoint: 127.0.0.1:13134
+    path: /healthz
   file_storage:
     directory: C:\ProgramData\Otelcol\FileStorage
     timeout: 10s


### PR DESCRIPTION
## Summary
- add the /healthz path to each collector health_check extension configuration so the health endpoint matches the expected location

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdda428f10832a9d82e56bc1f4d1b3