### PR TITLE
Bump one-page wallet card version

### DIFF
--- a/OPS_WALLET_CARD_ONE_PAGE.md
+++ b/OPS_WALLET_CARD_ONE_PAGE.md
@@ -70,4 +70,4 @@ sc.exe failureflag otelcol-contrib 1
 - **Quarterly**: `chaos-drill.ps1` (maintenance window) → verify resilience
 
 ---
-**Version:** v1.0.0 | **Compatibility:** PS 5.1+, Windows 10/11+ | **Emergency:** See ON_CALL_RUNBOOK.md
+**Version:** v1.1.0 | **Compatibility:** PS 5.1+, Windows 10/11+ | **Emergency:** See ON_CALL_RUNBOOK.md


### PR DESCRIPTION
## Summary
- update the one-page ops wallet card banner to use version v1.1.0 for consistency with the printable assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cded5afad8832a944fee5cb79f6948