### PR TITLE
Clarify weekly audit automation across wallet cards

### DIFF
--- a/OPS_WALLET_CARD.md
+++ b/OPS_WALLET_CARD.md
@@ -61,6 +61,6 @@ sc.exe failureflag otelcol-contrib 1
 - [ ] Canary delta output confirmation (`canary-check-min.ps1`)
 
 ## 🔄 Periodic Maintenance
-- **Weekly:** `make-audit-pack.ps1` → attach to ops log
+- **Weekly:** `setup-weekly-audit.ps1` → automated evidence trail; run `make-audit-pack.ps1` on-demand if you need a manual capture
 - **Monthly:** `repo-clean-inventory.ps1` (dry-run) → confirm no drift
 - **Quarterly:** `chaos-drill.ps1` (maintenance window) → verify resilience

--- a/OPS_WALLET_CARD_ONE_PAGE.md
+++ b/OPS_WALLET_CARD_ONE_PAGE.md
@@ -65,7 +65,7 @@ sc.exe failureflag otelcol-contrib 1
 - [ ] Canary delta output confirmation (`canary-check-min.ps1`)
 
 ## 🔄 Maintenance Schedule
-- **Weekly**: `make-audit-pack.ps1` → attach to ops log
+- **Weekly**: `setup-weekly-audit.ps1` → automated evidence trail; run `make-audit-pack.ps1` on-demand if you need a manual capture
 - **Monthly**: `repo-clean-inventory.ps1` (dry-run) → confirm no drift
 - **Quarterly**: `chaos-drill.ps1` (maintenance window) → verify resilience
 

--- a/OPS_WALLET_CARD_PRINTABLE.md
+++ b/OPS_WALLET_CARD_PRINTABLE.md
@@ -68,7 +68,7 @@ sc.exe failureflag otelcol-contrib 1
 - [ ] Canary delta output confirmation (`canary-check-min.ps1`)
 
 ## 🔄 MAINTENANCE SCHEDULE
-- **Weekly**: `setup-weekly-audit.ps1` → automated evidence trail (hands-off)
+- **Weekly**: `setup-weekly-audit.ps1` → automated evidence trail (hands-off); run `make-audit-pack.ps1` on-demand for manual capture
 - **Monthly**: `repo-clean-inventory.ps1` (dry-run) → confirm no drift
 - **Quarterly**: `chaos-drill.ps1` (maintenance window) → verify resilience
 - **CI/CD**: `post-deploy-smoke.ps1` → pipeline gate validation

--- a/generate-wallet-card-pdf.ps1
+++ b/generate-wallet-card-pdf.ps1
@@ -195,7 +195,7 @@ sc.exe failureflag otelcol-contrib 1</div>
 
     <div class="section">
         <h3>🔄 MAINTENANCE SCHEDULE</h3>
-        <div class="code">• Weekly: setup-weekly-audit.ps1 → automated evidence trail (hands-off)<br>
+        <div class="code">• Weekly: setup-weekly-audit.ps1 → automated evidence trail (hands-off); run make-audit-pack.ps1 on-demand for manual capture<br>
 • Monthly: repo-clean-inventory.ps1 (dry-run) → confirm no drift<br>
 • Quarterly: chaos-drill.ps1 (maintenance window) → verify resilience<br>
 • CI/CD: post-deploy-smoke.ps1 → pipeline gate validation</div>

--- a/wallet-card.html
+++ b/wallet-card.html
@@ -164,7 +164,7 @@ sc.exe failureflag otelcol-contrib 1</div>
 
     <div class="section">
         <h3>🔄 MAINTENANCE SCHEDULE</h3>
-        <div class="code">• Weekly: setup-weekly-audit.ps1 → automated evidence trail (hands-off)<br>
+        <div class="code">• Weekly: setup-weekly-audit.ps1 → automated evidence trail (hands-off); run make-audit-pack.ps1 on-demand for manual capture<br>
 • Monthly: repo-clean-inventory.ps1 (dry-run) → confirm no drift<br>
 • Quarterly: chaos-drill.ps1 (maintenance window) → verify resilience<br>
 • CI/CD: post-deploy-smoke.ps1 → pipeline gate validation</div>


### PR DESCRIPTION
## Summary
- point weekly maintenance guidance in the wallet cards at setup-weekly-audit.ps1 while noting make-audit-pack.ps1 as an on-demand option
- mirror the automation guidance across the printable, HTML, and generator assets so the weekly instructions stay consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cded5a12f0832a8c8370dc7d6a76e7