### PR TITLE
Ensure windows log source attribute is inserted

### DIFF
--- a/config/otelcol-windows.yaml
+++ b/config/otelcol-windows.yaml
@@ -31,9 +31,6 @@ processors:
       - key: log.source
         value: windows_event_log
         action: insert
-        conditions:
-          - key: log.source
-            value: windows_event_log
 
 exporters:
   otlp:


### PR DESCRIPTION
## Summary
- remove the attributes processor condition so log.source is inserted when missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d119f6ed64832a90ed00e0eeec0a0a