### PR TITLE
Add Windows Event Log receivers to collector config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,14 @@ receivers:
         from: attributes["log.file.name"]
         to: attributes["log.file.name"]
 
+  windowseventlog/application:
+    channel: Application
+    start_at: end
+
+  windowseventlog/system:
+    channel: System
+    start_at: end
+
 exporters:
   logging:
     loglevel: info
@@ -156,7 +164,7 @@ service:
       processors: [memory_limiter, resource/defaults, batch]
       exporters: [logging, otlp/sigz]
     logs:
-      receivers: [otlp, filelog, windowseventlog/application, prometheus/gpu]
+      receivers: [otlp, filelog, windowseventlog/application, windowseventlog/system]
       processors: [memory_limiter, filter/drop_noise, transform/sanitize, transform/enrich, attributes/redact, batch]
       exporters: [logging, otlp/sigz]
 


### PR DESCRIPTION
## Summary
- add explicit windowseventlog/application and windowseventlog/system receivers to the collector configuration
- adjust the logs pipeline to use the windowseventlog receivers and drop the prometheus/gpu receiver from logs

## Testing
- not run (Windows-only otelcol dry run command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d119f4a7b8832a8a5061cb3e1a89c8