### PR TITLE
Ensure log.source insert applies globally

### DIFF
--- a/config/otelcol-windows.yaml
+++ b/config/otelcol-windows.yaml
@@ -31,9 +31,6 @@ processors:
       - key: log.source
         value: windows_event_log
         action: insert
-        conditions:
-          - key: log.source
-            value: windows_event_log
 
 exporters:
   otlp:


### PR DESCRIPTION
## Summary
- collapse the collector attributes processors so both deployment.env and log.source inserts run globally
- rely on the insert action to set log.source=windows_event_log whenever the attribute is absent

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d119f6ed64832a90ed00e0eeec0a0a