### PR TITLE
Align OTLP endpoints with SigNoz host ports

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,7 +44,7 @@ exporters:
     loglevel: info
 
   otlp/sigz:
-    endpoint: "localhost:4317"
+    endpoint: "localhost:14317"
     tls:
       insecure: true
     retry_on_failure:

--- a/gpu-metrics-emitter.py
+++ b/gpu-metrics-emitter.py
@@ -9,6 +9,7 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import urlparse
 
 try:
     import pynvml
@@ -22,9 +23,22 @@ except ImportError as e:
     print("Please install: pip install opentelemetry-sdk opentelemetry-exporter-otlp nvidia-ml-py")
     exit(1)
 
+def _normalize_endpoint(endpoint: str) -> str:
+    """Convert http(s) style URLs to host:port targets for gRPC exporters."""
+    if "://" in endpoint:
+        parsed = urlparse(endpoint)
+        host = parsed.hostname or "localhost"
+        port = parsed.port
+        if port is None:
+            port = 443 if parsed.scheme == "https" else 80
+        return f"{host}:{port}"
+    return endpoint
+
+
 class GPUMetricsEmitter:
-    def __init__(self, otlp_endpoint="http://localhost:4317", service_name="gpu-monitor"):
-        self.otlp_endpoint = otlp_endpoint
+    def __init__(self, otlp_endpoint="localhost:14317", service_name="gpu-monitor"):
+        self.original_endpoint = otlp_endpoint
+        self.otlp_endpoint = _normalize_endpoint(otlp_endpoint)
         self.service_name = service_name
         
         # Initialize NVML
@@ -86,6 +100,8 @@ class GPUMetricsEmitter:
             # Create metrics
             self._create_metrics()
             
+            if self.otlp_endpoint != self.original_endpoint:
+                print(f"Normalized OTLP endpoint '{self.original_endpoint}' -> '{self.otlp_endpoint}'")
             print(f"OpenTelemetry metrics configured for {self.otlp_endpoint}")
             
         except Exception as e:
@@ -310,8 +326,8 @@ def main():
     import argparse
     
     parser = argparse.ArgumentParser(description="GPU Metrics Emitter for SigNoz")
-    parser.add_argument("--endpoint", default="http://localhost:4317", 
-                       help="OTLP endpoint (default: http://localhost:4317)")
+    parser.add_argument("--endpoint", default="localhost:14317",
+                       help="OTLP endpoint (default: localhost:14317; http(s) URLs are normalized)")
     parser.add_argument("--duration", type=int, default=300,
                        help="Duration in seconds (default: 300)")
     parser.add_argument("--interval", type=int, default=15,

--- a/gpu-metrics-simple.py
+++ b/gpu-metrics-simple.py
@@ -9,6 +9,7 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import urlparse
 
 try:
     import pynvml
@@ -22,9 +23,22 @@ except ImportError as e:
     print("Please install: pip install opentelemetry-sdk opentelemetry-exporter-otlp nvidia-ml-py")
     exit(1)
 
+def _normalize_endpoint(endpoint: str) -> str:
+    """Convert http(s) style URLs to host:port targets for gRPC exporters."""
+    if "://" in endpoint:
+        parsed = urlparse(endpoint)
+        host = parsed.hostname or "localhost"
+        port = parsed.port
+        if port is None:
+            port = 443 if parsed.scheme == "https" else 80
+        return f"{host}:{port}"
+    return endpoint
+
+
 class SimpleGPUMetricsEmitter:
-    def __init__(self, otlp_endpoint="http://localhost:4317", service_name="gpu-monitor"):
-        self.otlp_endpoint = otlp_endpoint
+    def __init__(self, otlp_endpoint="localhost:14317", service_name="gpu-monitor"):
+        self.original_endpoint = otlp_endpoint
+        self.otlp_endpoint = _normalize_endpoint(otlp_endpoint)
         self.service_name = service_name
         
         # Initialize NVML
@@ -83,6 +97,8 @@ class SimpleGPUMetricsEmitter:
             # Create meter
             self.meter = self.meter_provider.get_meter("gpu-metrics")
             
+            if self.otlp_endpoint != self.original_endpoint:
+                print(f"Normalized OTLP endpoint '{self.original_endpoint}' -> '{self.otlp_endpoint}'")
             print(f"OpenTelemetry metrics configured for {self.otlp_endpoint}")
             
         except Exception as e:
@@ -289,8 +305,8 @@ def main():
     import argparse
     
     parser = argparse.ArgumentParser(description="Simple GPU Metrics Emitter for SigNoz")
-    parser.add_argument("--endpoint", default="http://localhost:4317", 
-                       help="OTLP endpoint (default: http://localhost:4317)")
+    parser.add_argument("--endpoint", default="localhost:14317",
+                       help="OTLP endpoint (default: localhost:14317; http(s) URLs are normalized)")
     parser.add_argument("--duration", type=int, default=300,
                        help="Duration in seconds (default: 300)")
     parser.add_argument("--interval", type=int, default=15,

--- a/run-gpu-metrics.ps1
+++ b/run-gpu-metrics.ps1
@@ -2,7 +2,7 @@
 # PowerShell wrapper for gpu-metrics-emitter.py
 
 param(
-    [string]$OtlpEndpoint = "http://localhost:4317",
+    [string]$OtlpEndpoint = "localhost:14317",
     [int]$Duration = 300,
     [int]$Interval = 15,
     [switch]$Background,


### PR DESCRIPTION
## Summary
- point the Windows collector config at the dedicated SigNoz gRPC host port (14317)
- normalize GPU metrics emitters to accept URL-style endpoints and default to the same host port
- update the PowerShell GPU wrapper so local runs target the corrected endpoint

## Testing
- python -m compileall gpu-metrics-emitter.py gpu-metrics-simple.py

## ✅ ECRR Gate
- Examine — Audited OTLP endpoints across the Windows collector config and GPU emitter scripts; spotted mismatched ports and gRPC URL usage.
- Clean — Updated endpoints to the dedicated SigNoz host port and added normalization for URL inputs before running compile checks.
- Report — Captured the adjustments here for the team and noted the alignment across scripts.
- Role — ChatGPT Agent (Observability sibling)

------
https://chatgpt.com/codex/tasks/task_e_68d201ed0f54832a86e89efce1281cf5