### PR TITLE
Add codex-cloud audit artifacts and smoke harness

### DIFF
--- a/docs/otel/AUDIT_REPORT.md
+++ b/docs/otel/AUDIT_REPORT.md
@@ -1,0 +1,77 @@
+# OpenTelemetry Stack Audit — SSOT Snapshot
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Config integrity | 🔴 Needs fixes | Windows collector config fails to load because of undefined processors/exporters; tail sampling unused. |
+| Reliability & performance | 🟠 Gaps | No queue/backoff on core exporters; local harness lacks memory guardrails. |
+| Security & privacy | 🟡 Mixed | Legacy config redacts secrets, but active Windows config ships without sanitizers. |
+| Observability of observability | 🟢 Partial | Health checks in place, but no coverage for local test collector. |
+| Test / CI posture | 🟠 Gaps | Only syntax lint for one config; no deterministic smoke in CI. |
+| Runbooks & recovery | 🟢 Strong base | Detailed Windows break/fix steps exist; need condensed playbook for quick use. |
+
+## Executive Summary
+
+The current Windows → SigNoz observability stack contains **blocking configuration defects** (log pipeline references a non-existent processor/exporter) that will prevent the Windows collector from starting. Reliability controls on both the Windows and SigNoz collectors trail recommended baselines (no retry/queue envelope, missing memory limiter). Security posture regressed because the Windows config that is most prominently documented lacks the redaction/attribute controls present in the hardened baseline. CI only validates YAML syntax for a single file and has no automated smoke; operators rely on ad-hoc scripts. Introduce the attached findings, adopt the new smoke harness, and close the config gaps before promoting changes.
+
+## Findings by Theme
+
+### 1. Config integrity
+
+* **Windows collector config regression.** `config/otelcol-windows.yaml` defines `processors.batch/logs` but the log pipeline references `batch` and adds a `debug` exporter that is never defined, which causes startup failure. Metrics and traces pipelines contain empty receiver lists and also reference the undefined `batch` processor.【F:config/otelcol-windows.yaml†L1-L52】【F:config/otelcol-windows.yaml†L53-L74】
+* **Legacy config drift.** `config.yaml` wires sanitizers, filters, and tail sampling but only exposes a logs pipeline, so tail sampling never activates and there is no metrics/traces coverage. The file also omits exporter retry/queue configuration for the primary OTLP path.【F:config.yaml†L1-L72】【F:config.yaml†L73-L154】
+* **Local harness gaps.** `collector/otel-local.yaml` lacks `memory_limiter`, retry/queue controls, and any health extension, so it is unsuitable for sustained smoke use.【F:collector/otel-local.yaml†L1-L33】
+* **SigNoz collector exporter hardening outstanding.** `config/signoz-collector.yaml` enables batch processing but omits `memory_limiter` and leaves exporters without retry/backoff or queues, so transient failures can drop data.【F:config/signoz-collector.yaml†L1-L88】
+
+### 2. Reliability & performance
+
+* No queue/backoff envelopes on the primary OTLP exporters (`config/otelcol-windows.yaml`, `collector/otel-local.yaml`, `config/signoz-collector.yaml`), so bursts rely on best-effort delivery.【F:config/otelcol-windows.yaml†L34-L52】【F:collector/otel-local.yaml†L20-L33】【F:config/signoz-collector.yaml†L60-L88】
+* Memory guardrails are inconsistent: the production Windows config caps at 256 MiB without spike handling, the local harness has no limiter, and SigNoz collector has none.【F:config/otelcol-windows.yaml†L25-L38】【F:collector/otel-local.yaml†L18-L31】【F:config/signoz-collector.yaml†L19-L88】
+* SLO targets exist in `config/slo-config.json`, but there is no automation enforcing or reporting against them.【F:config/slo-config.json†L1-L17】
+
+### 3. Security & privacy
+
+* Hardened baseline (`config.yaml`) provides sanitization (`transform/sanitize`) and redaction processors, yet `config/otelcol-windows.yaml`—which is linked throughout the repo—omits them, so sensitive values can leak when teams follow the wrong config.【F:config.yaml†L27-L72】【F:config/otelcol-windows.yaml†L25-L52】
+* `docker-compose.yml` stores the SigNoz JWT secret inline, which is fine for local dev but should be parameterized before shared environments.【F:docker-compose.yml†L1-L59】
+
+### 4. Observability of the observability
+
+* Windows collector ships with a health extension, but the local smoke collector does not expose health or telemetry endpoints, limiting triage visibility.【F:config/otelcol-windows.yaml†L1-L24】【F:collector/otel-local.yaml†L1-L33】
+* SigNoz collector exports its own metrics (`prometheus` receiver) and health/pprof endpoints, which is good; add dashboards to watch exporter queue depth once queues exist.【F:config/signoz-collector.yaml†L1-L59】【F:config/signoz-collector.yaml†L60-L88】
+
+### 5. Test / CI posture
+
+* The only automation that validates collector configuration is `validate-yaml.py`, which runs against `config.yaml` only; no validation covers the Windows/SigNoz configs or ensures processor wiring is correct.【F:validate-yaml.py†L1-L22】
+* PowerShell scripts (`validate-pipeline.ps1`, `verify-pipeline.ps1`, `scripts/test-otel-integration.ps1`) exist but require manual invocation and are not wired into CI.【F:validate-pipeline.ps1†L1-L117】【F:verify-pipeline.ps1†L1-L46】【F:scripts/test-otel-integration.ps1†L1-L80】
+
+### 6. Runbooks & recovery
+
+* `ON_CALL_RUNBOOK.md` delivers deep recovery guidance, but responders still need a one-page quick reference and a deterministic smoke command; both are added in this audit.【F:ON_CALL_RUNBOOK.md†L1-L120】
+
+## Risk → Mitigation
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Windows collector fails to start due to undefined processors/exporters. | Complete loss of Windows log ingest. | Align processor/exporter names in `config/otelcol-windows.yaml` and remove unused pipelines or supply valid receivers. |
+| SigNoz collector drops data during ClickHouse hiccups. | Data loss under burst/backpressure. | Add `memory_limiter`, `retry_on_failure`, and `sending_queue` to all OTLP exporters in `config/signoz-collector.yaml`. |
+| Sensitive data leaks from Windows logs when teams copy the wrong config. | Compliance breach. | Promote `config-hardened-plus.yaml` as default or port its sanitizers into `config/otelcol-windows.yaml`. |
+| Smoke tests give false confidence because local collector has no guardrails. | Latent issues reach production. | Update `collector/otel-local.yaml` with memory limiter, queue controls, and health endpoint before using it in CI harness. |
+| CI misses config regressions. | Broken pipelines merge undetected. | Wire `scripts/otel/smoke.ps1` / `.sh` into CI alongside schema validation so pull requests exercise the full path. |
+
+## Evidence & Artifacts
+
+* Configuration issues and current baselines: `config/otelcol-windows.yaml`, `config.yaml`, `collector/otel-local.yaml`, `config/signoz-collector.yaml`.
+* Reliability targets: `config/slo-config.json`.
+* Manual validation tooling: `validate-yaml.py`, `validate-pipeline.ps1`, `verify-pipeline.ps1`, `scripts/test-otel-integration.ps1`.
+* Recovery documentation: `ON_CALL_RUNBOOK.md`.
+* New artifacts from this audit:
+  * `docs/otel/FINDINGS.json` — machine-readable findings list.
+  * `docs/otel/PLAYBOOK.md` — one-page break-glass playbook.
+  * `scripts/otel/smoke.ps1` and `scripts/otel/smoke.sh` — deterministic local smoke harness.
+
+## Next Steps
+
+1. Patch `config/otelcol-windows.yaml` to fix processor/exporter names, add sanitizers, and enable retry/queue envelopes.
+2. Backport hardened controls (`memory_limiter`, retries) to `collector/otel-local.yaml` and `config/signoz-collector.yaml`.
+3. Integrate the new smoke harness into CI (invoke PowerShell on Windows runners, Bash on Linux) so every PR exercises OTLP log/trace/metric round-trips.
+4. Publish dashboards that visualize collector health endpoints and queue depth once retry buffers are added.
+5. Redact or externalize secrets in `docker-compose.yml` before sharing images or running in staging/prod.

--- a/docs/otel/FINDINGS.json
+++ b/docs/otel/FINDINGS.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "CFG-001",
+    "severity": "critical",
+    "area": "config",
+    "desc": "Windows collector log pipeline references an undefined batch processor and debug exporter, preventing startup.",
+    "evidence": "config/otelcol-windows.yaml",
+    "fix": "Rename the processor to match `batch/logs` (or change the pipeline reference) and remove or define the debug exporter; drop empty metrics/traces pipelines or supply valid receivers."
+  },
+  {
+    "id": "CFG-002",
+    "severity": "high",
+    "area": "config",
+    "desc": "SigNoz collector exporters run without retry/backoff or memory limits, so transient ClickHouse outages drop data.",
+    "evidence": "config/signoz-collector.yaml",
+    "fix": "Add `memory_limiter` and enable `retry_on_failure` plus `sending_queue` on every OTLP exporter feeding ClickHouse." 
+  },
+  {
+    "id": "CFG-003",
+    "severity": "high",
+    "area": "config",
+    "desc": "Local smoke collector lacks memory limiter, queues, or health endpoint, so it is unsafe for CI harnessing.",
+    "evidence": "collector/otel-local.yaml",
+    "fix": "Port the production memory limiter, add retry/queue settings, and expose health telemetry before running in automation."
+  },
+  {
+    "id": "SEC-001",
+    "severity": "medium",
+    "area": "security",
+    "desc": "Teams copy `config/otelcol-windows.yaml`, which omits the sanitizer/redaction processors present in the hardened baseline.",
+    "evidence": "config/otelcol-windows.yaml",
+    "fix": "Promote `config-hardened-plus.yaml` as the canonical Windows config or add its redaction/sanitizer processors to `config/otelcol-windows.yaml`."
+  },
+  {
+    "id": "SEC-002",
+    "severity": "medium",
+    "area": "security",
+    "desc": "SigNoz JWT secret is committed inline in docker-compose, blocking reuse of the file in shared environments.",
+    "evidence": "docker-compose.yml",
+    "fix": "Externalize the JWT secret via environment file or secret manager before promoting beyond local development."
+  },
+  {
+    "id": "TEST-001",
+    "severity": "high",
+    "area": "testing",
+    "desc": "CI only runs a single YAML syntax check and never executes end-to-end smoke coverage for the OTel pipeline.",
+    "evidence": "validate-yaml.py",
+    "fix": "Add the new `scripts/otel/smoke.ps1` and `scripts/otel/smoke.sh` to CI so every PR exercises OTLP logs, traces, and metrics flow into SigNoz." 
+  }
+]

--- a/docs/otel/PLAYBOOK.md
+++ b/docs/otel/PLAYBOOK.md
@@ -1,0 +1,56 @@
+# Windows → SigNoz Break-Glass Playbook
+
+**Purpose:** One-screen checklist to restore log/trace/metric ingest from Windows hosts into SigNoz. Pair with the full `ON_CALL_RUNBOOK.md` for deep dives.
+
+---
+
+## 1. Snapshot (≤2 minutes)
+
+1. **Collector health**
+   ```powershell
+   Invoke-WebRequest -Uri http://127.0.0.1:13134/healthz -TimeoutSec 5 | ConvertFrom-Json
+   ```
+2. **SigNoz stack**
+   ```powershell
+   docker compose ps
+   docker exec signoz-clickhouse clickhouse-client -q "SELECT now(), count() FROM signoz_logs.logs_v2 LIMIT 1"
+   ```
+3. **Smoke harness** (runs synthetic log/trace/metric round-trip)
+   ```powershell
+   pwsh -File scripts/otel/smoke.ps1
+   ```
+
+If any command fails, capture output and proceed to triage.
+
+---
+
+## 2. Fast Triage
+
+| Symptom | Checks | Immediate Actions |
+| --- | --- | --- |
+| `otelcol-contrib` service stopped | `Get-Service otelcol-contrib`<br/>`Get-EventLog -LogName Application -Source "OpenTelemetry Collector" -Newest 5` | `Restart-Service otelcol-contrib`<br/>Re-run smoke. |
+| SigNoz collector unhealthy | `Invoke-WebRequest http://localhost:13133/healthz`<br/>`docker logs signoz-otel-collector --tail 200` | `docker compose restart signoz-otel-collector`<br/>Confirm ClickHouse up first. |
+| Smoke fails with batch/processor error | `Get-Content C:\otel\config.yaml`<br/>`& "C:\Program Files\OpenTelemetry Collector\otelcol-contrib.exe" --config C:\otel\config.yaml --dry-run` | Restore known-good config: `Copy-Item C:\otel\config-hardened-plus.yaml C:\otel\config.yaml -Force`. |
+| Drops/backpressure | `docker exec signoz-otel-collector curl -s http://localhost:8888/metrics | Select-String otelcol_exporter_queue_size` | Temporarily reduce ingest (disable noisy receivers) and size queue once config patches merge. |
+
+---
+
+## 3. Stabilize & Document
+
+1. **Lock in config**
+   ```powershell
+   Copy-Item C:\otel\config.yaml C:\otel\config.yaml.$(Get-Date -Format 'yyyyMMddHHmmss').bak
+   ```
+2. **Capture evidence**
+   ```powershell
+   pwsh -File scripts/otel/smoke.ps1 -SkipStackCheck > artifacts/smoke-$(Get-Date -Format 'yyyyMMddHHmmss').log
+   ```
+3. **Escalate if unresolved in 15 minutes** — send snapshot + smoke logs to the on-call channel.
+
+---
+
+## 4. Aftercare
+
+* File findings against `docs/otel/FINDINGS.json` IDs when applicable.
+* Schedule config hardening (memory limiter, queues) before re-enabling noisy sources.
+* Update dashboards to include collector health endpoints and queue depth once queues exist.

--- a/scripts/otel/smoke.ps1
+++ b/scripts/otel/smoke.ps1
@@ -1,0 +1,270 @@
+<#!
+.SYNOPSIS
+    Deterministic Windows → SigNoz smoke test for OTLP logs, traces, and metrics.
+
+.DESCRIPTION
+    Starts (or verifies) the local SigNoz stack, emits synthetic OTLP payloads, and asserts
+    that ClickHouse + SigNoz APIs observe the traffic. Designed for CI and on-call use.
+
+.PARAMETER SkipStackCheck
+    Skips docker-compose bring-up and health validation (use when stack already running).
+
+.PARAMETER TimeoutSeconds
+    Total seconds to wait for collectors to become healthy. Defaults to 120.
+
+.EXAMPLE
+    pwsh -File scripts/otel/smoke.ps1
+
+.EXAMPLE
+    pwsh -File scripts/otel/smoke.ps1 -SkipStackCheck
+#>
+[CmdletBinding()]
+param(
+    [switch]$SkipStackCheck,
+    [int]$TimeoutSeconds = 120
+)
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Stop'
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+function Write-Pass {
+    param([string]$Message)
+    Write-Host "   [OK] $Message" -ForegroundColor Green
+}
+
+function Write-Warn {
+    param([string]$Message)
+    Write-Host "   [WARN] $Message" -ForegroundColor Yellow
+}
+
+function Invoke-DockerCompose {
+    param(
+        [string[]]$Args
+    )
+
+    $cmd = "docker"
+    if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+        throw "docker CLI not found on PATH"
+    }
+
+    $fullArgs = @('compose') + $Args
+    $process = Start-Process -FilePath $cmd -ArgumentList $fullArgs -NoNewWindow -PassThru -Wait
+    if ($process.ExitCode -ne 0) {
+        throw "docker compose $($Args -join ' ') failed with exit code $($process.ExitCode)"
+    }
+}
+
+function Invoke-ClickHouseQuery {
+    param(
+        [string]$Query,
+        [switch]$Quiet
+    )
+
+    $queryArgs = @('exec', 'signoz-clickhouse', 'clickhouse-client', '--query', $Query)
+    $output = & docker @queryArgs 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        if (-not $Quiet) {
+            Write-Warn "ClickHouse query failed: $Query"
+        }
+        return $null
+    }
+    return $output
+}
+
+function Wait-ForUrl {
+    param(
+        [string]$Url,
+        [int]$Timeout = 60
+    )
+
+    $deadline = (Get-Date).AddSeconds($Timeout)
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $response = Invoke-WebRequest -Uri $Url -TimeoutSec 5
+            if ($response.StatusCode -eq 200) {
+                return $true
+            }
+        } catch {
+            Start-Sleep -Seconds 3
+        }
+    }
+    return $false
+}
+
+Write-Step "Preparing SigNoz stack"
+if (-not $SkipStackCheck) {
+    Invoke-DockerCompose -Args @('-f', 'docker-compose.yml', 'up', '-d')
+    Write-Pass "docker compose up -d"
+} else {
+    Write-Warn "Skipping docker compose up (per flag)"
+}
+
+if (-not (Wait-ForUrl -Url 'http://localhost:13133/healthz' -Timeout $TimeoutSeconds)) {
+    throw "SigNoz collector health endpoint did not become ready"
+}
+Write-Pass "SigNoz collector healthy on :13133"
+
+if (-not (Wait-ForUrl -Url 'http://localhost:8080/api/v1/health' -Timeout $TimeoutSeconds)) {
+    throw "SigNoz UI health endpoint did not respond"
+}
+Write-Pass "SigNoz UI reachable"
+
+$smokeId = "otel-smoke-" + ([Guid]::NewGuid().ToString())
+$nowNano = [int64]([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds() * 1000000)
+$spanEndNano = $nowNano + 5 * 1000000
+
+Write-Step "Emitting OTLP payloads ($smokeId)"
+
+$logPayload = @{
+    resourceLogs = @(
+        @{
+            resource = @{
+                attributes = @(
+                    @{ key = 'service.name'; value = @{ stringValue = 'windows-collector' } },
+                    @{ key = 'deployment.environment'; value = @{ stringValue = 'local-smoke' } }
+                )
+            }
+            scopeLogs = @(
+                @{
+                    scope = @{ name = 'smoke-harness'; version = '1.0.0' }
+                    logRecords = @(
+                        @{
+                            timeUnixNano = $nowNano.ToString()
+                            observedTimeUnixNano = $nowNano.ToString()
+                            severityNumber = 9
+                            severityText = 'INFO'
+                            body = @{ stringValue = "sig-smoke-log::$smokeId" }
+                            attributes = @(
+                                @{ key = 'smoke.id'; value = @{ stringValue = $smokeId } },
+                                @{ key = 'dataset'; value = @{ stringValue = 'smoke' } }
+                            )
+                        }
+                    )
+                }
+            )
+        }
+    )
+} | ConvertTo-Json -Depth 6
+
+$tracePayload = @{
+    resourceSpans = @(
+        @{
+            resource = @{
+                attributes = @(
+                    @{ key = 'service.name'; value = @{ stringValue = 'smoke-service' } },
+                    @{ key = 'deployment.environment'; value = @{ stringValue = 'local-smoke' } }
+                )
+            }
+            scopeSpans = @(
+                @{
+                    scope = @{ name = 'smoke-harness'; version = '1.0.0' }
+                    spans = @(
+                        @{
+                            traceId = ([System.BitConverter]::ToString((New-Guid).ToByteArray()) -replace '-', '').Substring(0,32)
+                            spanId = ([System.BitConverter]::ToString((New-Guid).ToByteArray()) -replace '-', '').Substring(0,16)
+                            name = 'smoke-span'
+                            kind = 'SPAN_KIND_INTERNAL'
+                            startTimeUnixNano = $nowNano.ToString()
+                            endTimeUnixNano = $spanEndNano.ToString()
+                            attributes = @(
+                                @{ key = 'smoke.id'; value = @{ stringValue = $smokeId } },
+                                @{ key = 'smoke.phase'; value = @{ stringValue = 'harness' } }
+                            )
+                        }
+                    )
+                }
+            )
+        }
+    )
+} | ConvertTo-Json -Depth 6
+
+$metricPayload = @{
+    resourceMetrics = @(
+        @{
+            resource = @{
+                attributes = @(
+                    @{ key = 'service.name'; value = @{ stringValue = 'smoke-service' } },
+                    @{ key = 'deployment.environment'; value = @{ stringValue = 'local-smoke' } }
+                )
+            }
+            scopeMetrics = @(
+                @{
+                    scope = @{ name = 'smoke-harness'; version = '1.0.0' }
+                    metrics = @(
+                        @{
+                            name = 'smoke_gauge'
+                            unit = '1'
+                            gauge = @{
+                                dataPoints = @(
+                                    @{
+                                        timeUnixNano = $nowNano.ToString()
+                                        asDouble = 1.0
+                                        attributes = @(
+                                            @{ key = 'smoke.id'; value = @{ stringValue = $smokeId } }
+                                        )
+                                    }
+                                )
+                            }
+                        }
+                    )
+                }
+            )
+        }
+    )
+} | ConvertTo-Json -Depth 6
+
+Invoke-RestMethod -Uri 'http://localhost:4318/v1/logs' -Method Post -Body $logPayload -ContentType 'application/json'
+Write-Pass "OTLP log accepted"
+Invoke-RestMethod -Uri 'http://localhost:4318/v1/traces' -Method Post -Body $tracePayload -ContentType 'application/json'
+Write-Pass "OTLP trace accepted"
+Invoke-RestMethod -Uri 'http://localhost:4318/v1/metrics' -Method Post -Body $metricPayload -ContentType 'application/json'
+Write-Pass "OTLP metric accepted"
+
+Start-Sleep -Seconds 10
+
+Write-Step "Verifying ingestion"
+$logCountRaw = Invoke-ClickHouseQuery -Query "SELECT count() FROM signoz_logs.distributed_logs_v2 WHERE JSONExtractString(body, 'smoke.id') = '$smokeId'"
+$logCount = 0
+if ([int]::TryParse(($logCountRaw | Select-Object -First 1), [ref]$logCount)) {
+    if ($logCount -gt 0) {
+        Write-Pass "Log present in ClickHouse"
+    } else {
+        Write-Warn "Log not found in ClickHouse (smoke id: $smokeId)"
+    }
+} elseif ($null -eq $logCountRaw) {
+    Write-Warn "Unable to query ClickHouse logs"
+}
+
+$traceCountRaw = Invoke-ClickHouseQuery -Query "SELECT count() FROM signoz_traces.signoz_index_v2 WHERE attributes_string['smoke.id'] = '$smokeId'"
+$traceCount = 0
+if ([int]::TryParse(($traceCountRaw | Select-Object -First 1), [ref]$traceCount)) {
+    if ($traceCount -gt 0) {
+        Write-Pass "Trace present in ClickHouse"
+    } else {
+        Write-Warn "Trace not found in ClickHouse"
+    }
+} elseif ($null -eq $traceCountRaw) {
+    Write-Warn "Unable to query ClickHouse traces"
+}
+
+$promQuery = "smoke_gauge{smoke_id='${smokeId}'}"
+$promUrl = "http://localhost:8080/api/v1/prometheus/api/v1/query?query=" + [System.Uri]::EscapeDataString($promQuery)
+try {
+    $metricResponse = Invoke-RestMethod -Uri $promUrl -TimeoutSec 15
+    $result = $metricResponse.data.result
+    if ($result -and $result.Count -gt 0) {
+        Write-Pass "Metric visible via PromQL"
+    } else {
+        Write-Warn "Metric not returned by PromQL (smoke id: $smokeId)"
+    }
+} catch {
+    Write-Warn "PromQL query failed: $($_.Exception.Message)"
+}
+
+Write-Step "Smoke complete"
+Write-Host "Smoke ID: $smokeId" -ForegroundColor White

--- a/scripts/otel/smoke.sh
+++ b/scripts/otel/smoke.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SMOKE_ID="otel-smoke-$(uuidgen | tr 'A-Z' 'a-z')"
+TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-120}
+SKIP_STACK_CHECK=${SKIP_STACK_CHECK:-0}
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+log() { printf '\n==> %s\n' "$1"; }
+pass() { printf '   [OK] %s\n' "$1"; }
+warn() { printf '   [WARN] %s\n' "$1"; }
+
+wait_for() {
+  local url=$1
+  local deadline=$((SECONDS + TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    if curl -sf "$url" >/dev/null; then
+      return 0
+    fi
+    sleep 3
+  done
+  return 1
+}
+
+log "Preparing SigNoz stack"
+if [[ "$SKIP_STACK_CHECK" != "1" ]]; then
+  (cd "$ROOT_DIR" && docker compose -f docker-compose.yml up -d)
+  pass "docker compose up -d"
+else
+  warn "Skipping docker compose bring-up"
+fi
+
+wait_for http://localhost:13133/healthz || { echo "SigNoz collector health endpoint not ready" >&2; exit 1; }
+pass "SigNoz collector healthy"
+wait_for http://localhost:8080/api/v1/health || { echo "SigNoz UI health endpoint not ready" >&2; exit 1; }
+pass "SigNoz UI reachable"
+
+log "Emitting OTLP payloads ($SMOKE_ID)"
+SMOKE_ID=$SMOKE_ID TMP_DIR=$TMP_DIR python3 - <<'PY'
+import json, os, time, uuid
+
+smoke_id = os.environ["SMOKE_ID"]
+tmp_dir = os.environ["TMP_DIR"]
+now_ns = int(time.time() * 1_000_000_000)
+span_end_ns = now_ns + 5_000_000
+
+log_payload = {
+    "resourceLogs": [
+        {
+            "resource": {
+                "attributes": [
+                    {"key": "service.name", "value": {"stringValue": "windows-collector"}},
+                    {"key": "deployment.environment", "value": {"stringValue": "local-smoke"}}
+                ]
+            },
+            "scopeLogs": [
+                {
+                    "scope": {"name": "smoke-harness", "version": "1.0.0"},
+                    "logRecords": [
+                        {
+                            "timeUnixNano": str(now_ns),
+                            "observedTimeUnixNano": str(now_ns),
+                            "severityNumber": 9,
+                            "severityText": "INFO",
+                            "body": {"stringValue": f"sig-smoke-log::{smoke_id}"},
+                            "attributes": [
+                                {"key": "smoke.id", "value": {"stringValue": smoke_id}},
+                                {"key": "dataset", "value": {"stringValue": "smoke"}}
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+
+trace_payload = {
+    "resourceSpans": [
+        {
+            "resource": {
+                "attributes": [
+                    {"key": "service.name", "value": {"stringValue": "smoke-service"}},
+                    {"key": "deployment.environment", "value": {"stringValue": "local-smoke"}}
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {"name": "smoke-harness", "version": "1.0.0"},
+                    "spans": [
+                        {
+                            "traceId": uuid.uuid4().hex,
+                            "spanId": uuid.uuid4().hex[:16],
+                            "name": "smoke-span",
+                            "kind": "SPAN_KIND_INTERNAL",
+                            "startTimeUnixNano": str(now_ns),
+                            "endTimeUnixNano": str(span_end_ns),
+                            "attributes": [
+                                {"key": "smoke.id", "value": {"stringValue": smoke_id}},
+                                {"key": "smoke.phase", "value": {"stringValue": "harness"}}
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+
+metric_payload = {
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {"key": "service.name", "value": {"stringValue": "smoke-service"}},
+                    {"key": "deployment.environment", "value": {"stringValue": "local-smoke"}}
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {"name": "smoke-harness", "version": "1.0.0"},
+                    "metrics": [
+                        {
+                            "name": "smoke_gauge",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "timeUnixNano": str(now_ns),
+                                        "asDouble": 1.0,
+                                        "attributes": [
+                                            {"key": "smoke.id", "value": {"stringValue": smoke_id}}
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+
+with open(os.path.join(tmp_dir, "logs.json"), "w", encoding="utf-8") as fh:
+    json.dump(log_payload, fh)
+with open(os.path.join(tmp_dir, "traces.json"), "w", encoding="utf-8") as fh:
+    json.dump(trace_payload, fh)
+with open(os.path.join(tmp_dir, "metrics.json"), "w", encoding="utf-8") as fh:
+    json.dump(metric_payload, fh)
+PY
+
+curl -sf -o /dev/null -X POST -H 'Content-Type: application/json' --data "@${TMP_DIR}/logs.json" http://localhost:4318/v1/logs
+pass "OTLP log accepted"
+curl -sf -o /dev/null -X POST -H 'Content-Type: application/json' --data "@${TMP_DIR}/traces.json" http://localhost:4318/v1/traces
+pass "OTLP trace accepted"
+curl -sf -o /dev/null -X POST -H 'Content-Type: application/json' --data "@${TMP_DIR}/metrics.json" http://localhost:4318/v1/metrics
+pass "OTLP metric accepted"
+
+sleep 10
+
+log "Verifying ingestion"
+if log_count=$(docker exec signoz-clickhouse clickhouse-client --query "SELECT count() FROM signoz_logs.distributed_logs_v2 WHERE JSONExtractString(body, 'smoke.id') = '${SMOKE_ID}'" 2>/dev/null); then
+  if [[ "$log_count" -gt 0 ]]; then
+    pass "Log present in ClickHouse"
+  else
+    warn "Log not found in ClickHouse"
+  fi
+else
+  warn "Unable to query ClickHouse for logs"
+fi
+
+if trace_count=$(docker exec signoz-clickhouse clickhouse-client --query "SELECT count() FROM signoz_traces.signoz_index_v2 WHERE attributes_string['smoke.id'] = '${SMOKE_ID}'" 2>/dev/null); then
+  if [[ "$trace_count" -gt 0 ]]; then
+    pass "Trace present in ClickHouse"
+  else
+    warn "Trace not found in ClickHouse"
+  fi
+else
+  warn "Unable to query ClickHouse for traces"
+fi
+
+PROM_QUERY=$(python3 - <<'PY'
+import urllib.parse, os
+print(urllib.parse.quote(f"smoke_gauge{{smoke_id='{os.environ['SMOKE_ID']}'}}"))
+PY
+)
+if prom_response=$(curl -sf "http://localhost:8080/api/v1/prometheus/api/v1/query?query=${PROM_QUERY}"); then
+  if PROM_RESPONSE="$prom_response" python3 - <<'PY'
+import json, os, sys
+response = json.loads(os.environ['PROM_RESPONSE'])
+result = response.get('data', {}).get('result', [])
+if result:
+    sys.exit(0)
+sys.exit(1)
+PY
+  then
+    pass "Metric visible via PromQL"
+  else
+    warn "Metric not returned via PromQL"
+  fi
+else
+  warn "PromQL query failed"
+fi
+
+log "Smoke complete"
+printf 'Smoke ID: %s\n' "$SMOKE_ID"


### PR DESCRIPTION
## Summary
- capture the codex-cloud audit in `docs/otel/AUDIT_REPORT.md` with linked evidence and prioritized findings
- publish `docs/otel/FINDINGS.json` and `docs/otel/PLAYBOOK.md` to give coordinators machine-readable risks and a one-page break-glass guide
- ship cross-platform `scripts/otel/smoke.ps1` and `scripts/otel/smoke.sh` to provide deterministic OTLP smoke coverage for CI

## Testing
- npm run lint

## ✅ ECRR Gate
- **Examine:** Documented collector drift and exporter gaps in `docs/otel/AUDIT_REPORT.md`
- **Clean:** Added smoke harness and mitigation guidance under `docs/otel/` and `scripts/otel/`
- **Report:** SSOT summary + findings JSON ready for review in this PR
- **Role:** ChatGPT Agent (codex-cloud coordinator)

------
https://chatgpt.com/codex/tasks/task_e_68d3f7bf35d4832a8aa5d67d7da68445