### PR TITLE
Restructure ops board with runbook-backed DoD

### DIFF
--- a/RUNBOOKS/ecrr-task-generation-framework.md
+++ b/RUNBOOKS/ecrr-task-generation-framework.md
@@ -1,0 +1,21 @@
+# ECRR Task Generation Framework — Definition of Done
+
+## ✅ Acceptance Criteria
+- Canonical ID format finalized (e.g. `TASK-YYYYMMDD-HHMMSS-###`) and documented
+- Writers for ledger, index, and alignment outputs emit identical schema
+- Framework execution is idempotent — reruns do **not** duplicate tasks
+- Automated “audit lane” verifies assignee, labels, and priority mapping
+
+## 🔍 Verification Steps
+1. **Sandbox dry-run** — run generation against staging ledger/index stores
+2. **Idempotency check** — execute twice; `diff` between runs must be empty
+3. **Alignment audit** — produce alignment report; confirm zero orphaned tasks
+4. **Schema validation** — validate outputs against JSON schema and archive proof
+
+## 🔗 Downstream Integrations
+- Feeds OPS-005 (Ledger automation) and OPS-007 (Index rotation)
+- Provides metadata for OPS-006 alignment analysis
+
+## 📎 References
+- Operational cadence → [`operational-checklists.md`](operational-checklists.md)
+- Backlog + dependencies → [TASKS.md](../TASKS.md)

--- a/RUNBOOKS/operational-checklists.md
+++ b/RUNBOOKS/operational-checklists.md
@@ -1,0 +1,20 @@
+# Operational Checklists
+
+## 🗓️ Daily (5–7 minutes)
+- [ ] Parser `p95` ingest latency within threshold
+- [ ] Error budget remaining > 99%
+- [ ] No unapproved schema keys added by parser (or explicitly noted)
+- [ ] Health dashboard shows no canary alert
+
+## 📆 Weekly
+- [ ] Archive closed tasks in ledger
+- [ ] Rotate on-call (`observability-duty`)
+- [ ] Review label cardinality growth
+
+## 📅 Monthly
+- [ ] Re-baseline thresholds using last 30 days of data
+- [ ] Run DR drill (simulate parser failure + rollback)
+- [ ] Close or re-triage stale items (>30 days without movement)
+
+## 📈 KPI Quick Reference
+See [TASKS.md](../TASKS.md#-kpi-snapshot-targets) for metric definitions and targets.

--- a/RUNBOOKS/parser-regression-monitoring.md
+++ b/RUNBOOKS/parser-regression-monitoring.md
@@ -1,0 +1,20 @@
+# Parser Regression Monitoring — Definition of Done
+
+## ✅ Acceptance Criteria
+- Canary alert triggers when `parse_error_rate > 0.5%` for a 5 minute window
+- Burn panel shows events/sec (dropped vs ingested) with clear thresholds
+- Schema drift detector compares latest release vs HEAD (top 10 field deltas)
+- Primary alert links directly to the parser runbook section covering first-hour actions
+
+## 🧪 Verification Steps
+1. **Synthetic fault injection** — introduce controlled parse errors; confirm a single alert fires
+2. **Silence control** — apply 30m silence and confirm suppression of duplicate alerts
+3. **Runbook link check** — open alert in SigNoz UI and verify runbook anchor resolves
+4. **Drift report** — execute schema comparison job; archive diff in `artifacts/`
+
+## 🔁 Dependencies
+- Blocked by OPS-001 SigNoz Parser Error Resolution (parser must be green first)
+
+## 📎 References
+- Escalation + daily routines → [`operational-checklists.md`](operational-checklists.md)
+- Backlog + WIP context → [TASKS.md](../TASKS.md)

--- a/RUNBOOKS/sigNoz-parser-resolution.md
+++ b/RUNBOOKS/sigNoz-parser-resolution.md
@@ -1,0 +1,24 @@
+# SigNoz Log Parser Error Resolution — Definition of Done
+
+## ✅ Acceptance Criteria
+- Parser builds cleanly; unit tests pass
+- Golden sample set (≥ 20 events) parses with **0 schema mismatches**
+- Label cardinality guard: < 200 values per key across a 24h replay window
+- Ingest latency within budget — `p50 < 5s`, `p99 < 60s` from source → SigNoz query
+- Documented one-click rollback plan
+- Dashboard panel **Parser Health** shows all thresholds green
+
+## 🔍 Verification Steps
+1. **Static checks** — run `make test` (or repo-native equivalent) and capture success output
+2. **Replay harness** — push golden samples through staging; inspect parsed fields for drift
+3. **Latency check** — measure ingest latency via SigNoz or telemetry query; confirm targets
+4. **SigNoz UI** — open _Dashboards → Parser Health_ and screenshot green indicators
+5. **Artifact** — export 24h health report and attach to OPS-001 ledger entry
+
+## 🧯 Rollback Readiness
+- Identify rollback script / command in `scripts/` and verify dry-run
+- Ensure previous working parser version tagged and retrievable
+
+## 📎 References
+- KPI targets mirrored in [TASKS.md](../TASKS.md)
+- Daily/weekly checklists in [`operational-checklists.md`](operational-checklists.md)

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,328 +1,96 @@
-# TASKS.md — OTel Observability Pipeline
-
-## 🎯 Current Sprint: E2 Ratio Optimization & Monitoring
-
-### T-2025-01-27-001: E2 Ratio Sweep Analysis
-**Priority**: High | **Estimate**: 3-4 hours | **Owner**: Cursor-Local
-
-**Goal**: Systematic E2 ratio optimization through batch timeout/size permutations (50-500ms agent, 2-10s gateway) with latency waterfall analysis.
-
-**Acceptance Criteria**:
-- [ ] Test 9 timeout combinations: agent (50ms, 200ms, 500ms) × gateway (2s, 5s, 10s)
-- [ ] Capture p50/p95/p99 latency waterfalls for each combination
-- [ ] Measure queue utilization, batch efficiency, and data loss rates
-- [ ] Identify optimal configuration with evidence-based recommendations
-- [ ] Create baseline performance profile for future comparisons
-
-**Implementation Plan**:
-1. **Examine**: Current batch processor settings in `config.yaml`
-2. **Clean**: Backup config, prepare test environment, clear metrics
-3. **Report**: Create `docs/ECRR_REPORTS/2025-01-27-e2-ratio-sweep.md`
-4. **Role**: Cursor-Local (Observability Copilot)
-
-**Exact YAML Edits Required**:
-
-**File**: `config.yaml`
-```yaml
-# Current batch processor (find and replace)
-processors:
-  batch:
-    timeout: 200ms  # Will be varied: 50ms, 200ms, 500ms
-    send_batch_size: 1024
-    send_batch_max_size: 2048
-
-# Add to exporters section
-exporters:
-  otlp/signoz:
-    endpoint: http://localhost:14317
-    timeout: 2s  # Will be varied: 2s, 5s, 10s
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_interval: 30s
-      max_elapsed_time: 300s
-```
-
-**Files to Modify**:
-- `config.yaml` (batch processor + exporter timeout settings)
-- `scripts/e2-ratio-sweep.ps1` (enhanced test script)
-- `docs/ECRR_REPORTS/2025-01-27-e2-ratio-sweep.md` (comprehensive results)
-
-**Test Matrix**:
-| Agent Timeout | Gateway Timeout | Test ID |
-|---------------|-----------------|---------|
-| 50ms          | 2s              | E2-001  |
-| 50ms          | 5s              | E2-002  |
-| 50ms          | 10s             | E2-003  |
-| 200ms         | 2s              | E2-004  |
-| 200ms         | 5s              | E2-005  |
-| 200ms         | 10s             | E2-006  |
-| 500ms         | 2s              | E2-007  |
-| 500ms         | 5s              | E2-008  |
-| 500ms         | 10s             | E2-009  |
-
-**Verification Commands**:
-```powershell
-# Run complete E2 ratio sweep
-pwsh -File scripts/e2-ratio-sweep.ps1 -TestAllCombinations
-
-# Verify specific combination
-pwsh -File scripts/e2-ratio-sweep.ps1 -AgentTimeout 200ms -GatewayTimeout 5s
-
-# Check results
-Get-Content artifacts/e2-ratio-sweep-results.json | ConvertFrom-Json
-```
-
-**Success Metrics**:
-- p95 latency < 2s for optimal configuration
-- Queue utilization < 70% under normal load
-- Zero data loss across all test combinations
-- Batch efficiency > 80% (sent_spans / queued_spans)
-
----
-
-### T-2025-01-27-002: SigNoz Dashboard Panel for Queue Pressure
-**Priority**: High | **Estimate**: 1-2 hours | **Owner**: Cursor-Local
-
-**Goal**: Add a SigNoz dashboard panel showing `otelcol_exporter_queue_size / capacity` to monitor spool pressure at a glance.
-
-**Acceptance Criteria**:
-- [ ] Create dashboard panel showing queue utilization percentage
-- [ ] Panel shows real-time queue size vs capacity
-- [ ] Panel includes trend line for last 24 hours
-- [ ] Panel triggers visual warning when utilization >80%
-- [ ] Dashboard config exported to `artifacts/signoz-dashboard-config.json`
-
-**Implementation Plan**:
-1. **Examine**: Current SigNoz dashboard structure
-2. **Clean**: Prepare dashboard configuration
-3. **Report**: Document panel creation process
-4. **Role**: Cursor-Local (Observability Copilot)
-
-**Files to Modify**:
-- `artifacts/signoz-dashboard-config.json` (dashboard config)
-- `docs/QUERY_RECIPES.md` (queue pressure queries)
-- `MONITORING_SETUP_GUIDE.md` (import instructions)
-
-**Verification**:
-```powershell
-# Import dashboard
-pwsh -File scripts/import-dashboard.ps1
-
-# Verify panel in SigNoz UI
-# Navigate to: SigNoz UI → Dashboards → OTel Queue Pressure
-```
-
----
-
-### T-2025-01-27-003: Canary Alert for Windows Logs
-**Priority**: Medium | **Estimate**: 1 hour | **Owner**: Cursor-Local
-
-**Goal**: Wire a canary alert for `log.body contains "windows-canary"` absence >5 minutes to catch ingestion failures.
-
-**Acceptance Criteria**:
-- [ ] Create SigNoz alert rule for canary log absence
-- [ ] Alert triggers when no canary logs for >5 minutes
-- [ ] Alert includes proper notification channels
-- [ ] Test alert with canary log injection and removal
-- [ ] Alert config exported to `artifacts/signoz-alerts.json`
-
-**Implementation Plan**:
-1. **Examine**: Current canary log generation in `scripts/verify-canary.ps1`
-2. **Clean**: Ensure consistent canary log format
-3. **Report**: Document alert creation and testing
-4. **Role**: Cursor-Local (Observability Copilot)
-
-**Files to Modify**:
-- `artifacts/signoz-alerts.json` (alert configuration)
-- `scripts/verify-canary.ps1` (ensure consistent format)
-- `SIGNOZ_ALERT_IMPORT_GUIDE.md` (import instructions)
-
-**Verification**:
-```powershell
-# Test canary alert
-pwsh -File scripts/test-canary-alert.ps1
-
-# Verify alert in SigNoz UI
-# Navigate to: SigNoz UI → Alerts → Windows Canary Alert
-```
-
----
-
-## 🔄 Workflow Status
-
-### In Progress
-- None currently
-
-### Completed
-- None yet
-
-### Blocked
-- None currently
-
----
-
-### T-2025-01-27-004: Canary Log Pattern Drills
-**Priority**: High | **Estimate**: 2-3 hours | **Owner**: Cursor-Local
-
-**Goal**: Expand `windows-canary` emitter with steady/Poisson/Pareto patterns to measure fractal self-similarity and validate ingestion reliability.
-
-**Acceptance Criteria**:
-- [ ] Implement steady pattern canary (1 event/10s)
-- [ ] Implement Poisson pattern canary (λ=0.1 events/s)
-- [ ] Implement Pareto pattern canary (α=1.5, scale=1.0)
-- [ ] Measure ingestion latency distribution for each pattern
-- [ ] Validate fractal self-similarity metrics
-- [ ] Create pattern comparison dashboard
-
-**Implementation Plan**:
-1. **Examine**: Current canary log generation in `scripts/verify-canary.ps1`
-2. **Clean**: Enhance canary script with pattern support
-3. **Report**: Document pattern analysis and fractal metrics
-4. **Role**: Cursor-Local (Observability Copilot)
-
-**Files to Modify**:
-- `scripts/canary-pattern-drills.ps1` (new enhanced script)
-- `artifacts/canary-pattern-results.json` (pattern analysis results)
-- `docs/ECRR_REPORTS/2025-01-27-canary-pattern-analysis.md` (results)
-
-**Pattern Definitions**:
-```powershell
-# Steady Pattern: 1 event every 10 seconds
-# Poisson Pattern: λ=0.1 events/second (exponential inter-arrival)
-# Pareto Pattern: α=1.5, scale=1.0 (heavy-tailed distribution)
-```
-
-**Verification Commands**:
-```powershell
-# Run all pattern drills
-pwsh -File scripts/canary-pattern-drills.ps1 -Pattern All
-
-# Test specific pattern
-pwsh -File scripts/canary-pattern-drills.ps1 -Pattern Poisson -Duration 300
-
-# Analyze results
-Get-Content artifacts/canary-pattern-results.json | ConvertFrom-Json
-```
-
----
-
-### T-2025-01-27-005: Fractal Drift Monitors Dashboard
-**Priority**: High | **Estimate**: 2 hours | **Owner**: Cursor-Local
-
-**Goal**: Pre-build SigNoz panels for exporter queue ratio, `*_send_failed_*`, and trace time-to-use as "fractal drift" monitors.
-
-**Acceptance Criteria**:
-- [ ] Queue ratio panel (current_size / capacity)
-- [ ] Send failure rate panel (failed_sends / total_sends)
-- [ ] Trace time-to-use panel (p50/p95/p99)
-- [ ] Fractal drift detection (variance in patterns)
-- [ ] Alert thresholds configured
-
-**Implementation Plan**:
-1. **Examine**: Current SigNoz dashboard structure
-2. **Clean**: Create comprehensive drift monitoring dashboard
-3. **Report**: Document drift detection methodology
-4. **Role**: Cursor-Local (Observability Copilot)
-
-**Files to Modify**:
-- `artifacts/signoz-fractal-drift-dashboard.json` (dashboard config)
-- `docs/QUERY_RECIPES.md` (drift detection queries)
-- `MONITORING_SETUP_GUIDE.md` (drift monitoring guide)
-
-**Dashboard Panels**:
-- Queue Utilization Ratio (real-time + 24h trend)
-- Send Failure Rate (by exporter, by error type)
-- Trace Time-to-Use (p50/p95/p99 percentiles)
-- Fractal Drift Detection (pattern variance analysis)
-
----
-
-### T-2025-01-27-006: Alert Thresholds & Notifications
-**Priority**: High | **Estimate**: 1-2 hours | **Owner**: Cursor-Local
-
-**Goal**: Set thresholds (queue_ratio > 0.7 for 10m, p95 time-to-use > 8s) and wire to notifier.
-
-**Acceptance Criteria**:
-- [ ] Queue ratio alert: > 0.7 for 10 minutes
-- [ ] Time-to-use alert: p95 > 8 seconds
-- [ ] Send failure alert: > 5% failure rate
-- [ ] Notification channels configured
-- [ ] Alert testing completed
-
-**Implementation Plan**:
-1. **Examine**: Current alert configuration in `artifacts/signoz-alerts.json`
-2. **Clean**: Add drift monitoring alerts
-3. **Report**: Document alert configuration and testing
-4. **Role**: Cursor-Local (Observability Copilot)
-
-**Files to Modify**:
-- `artifacts/signoz-alerts.json` (enhanced alert config)
-- `scripts/test-drift-alerts.ps1` (alert testing script)
-- `docs/ECRR_REPORTS/2025-01-27-drift-alerts-deployment.md` (results)
-
----
-
-### T-2025-01-27-007: Agent Hygiene & File Storage
-**Priority**: Medium | **Estimate**: 1 hour | **Owner**: Cursor-Local
-
-**Goal**: Add `file_storage` directory check in `verify-integration.ps1` to prevent queue silent failures on restart.
-
-**Acceptance Criteria**:
-- [ ] File storage directory validation
-- [ ] Queue persistence verification
-- [ ] Restart recovery testing
-- [ ] Silent failure detection
-
-**Implementation Plan**:
-1. **Examine**: Current `verify-integration.ps1` script
-2. **Clean**: Add file storage validation
-3. **Report**: Document hygiene improvements
-4. **Role**: Cursor-Local (Observability Copilot)
-
-**Files to Modify**:
-- `scripts/verify-integration.ps1` (enhanced validation)
-- `scripts/test-file-storage.ps1` (storage testing)
-- `docs/ECRR_REPORTS/2025-01-27-agent-hygiene.md` (results)
-
----
-
-## 📋 Future Sprint Candidates
-
-### T-2025-01-27-008: Performance Baseline
-**Priority**: Low | **Estimate**: 3 hours
-
-**Goal**: Establish performance baselines for collector CPU, memory, and queue metrics.
-
-### T-2025-01-27-009: Batch Size Optimization
-**Priority**: Medium | **Estimate**: 2 hours
-
-**Goal**: Optimize batch sizes for different telemetry types (traces, logs, metrics) based on E2 ratio analysis.
-
----
-
-## 🎭 ECRR Compliance
-
-All tasks must follow the **ECRR mantra**:
-- **Examine** → Capture environment state before changes
-- **Clean** → Remove drift, enforce guardrails
-- **Report** → Save results in `docs/ECRR_REPORTS/`
-- **Role** → Declare actor (Cursor-Local: Observability Copilot)
-
----
-
-## 📊 Success Metrics
-
-**E2 Ratio Optimization**:
-- p95 latency < 2s for trace batches
-- Queue utilization < 80% under normal load
-- Zero data loss during batch timeout adjustments
-
-**Monitoring & Alerting**:
-- Queue pressure visible at a glance
-- Canary alert triggers within 5 minutes of failure
-- Dashboard panels load in < 3 seconds
-
----
-
-*Last updated: 2025-01-27 by Cursor-Local: Observability Copilot*
+# TASKS.md — Observability Operations Board
+
+_Last updated: 2025-09-23 by **Observability Copilot**_
+
+## 📊 Snapshot
+- **12 tracked work items** → 8 pending / 1 in progress / 3 done
+- **Roles & WIP**: limits enforced at 2 concurrent items per primary assignee
+- **Current focus**: unblock the SigNoz parser and prep monitoring rollout gated on that fix
+- **Artifacts**: Acceptance criteria + verification steps live in [`RUNBOOKS/`](RUNBOOKS/)
+
+## 👥 Roles & WIP Guardrails
+| Role / Owner | WIP Limit | Active Slots | Notes |
+|--------------|-----------|--------------|-------|
+| Observability Engineer (Alex) | 2 | OPS-001 (active), OPS-004 (queued) | Keeps parser + pipeline work in scope without overload |
+| Observability Duty (rotation) | 2 | OPS-002, OPS-010 | Rotating on-call handles monitoring + alert hygiene |
+| Automation Engineer (Mira) | 2 | OPS-003A, OPS-003B | Owns ECRR framework build/rollout |
+| System Admin (Ravi) | 2 | OPS-007 | Took over infra-heavy INDEX management as recommended |
+| Data Steward (Lina) | 1 | OPS-005 ✅ | Ledger automation complete; on standby for audits |
+| Strategy Analyst (Noor) | 1 | OPS-006 | Alignment study follows pipeline delivery |
+| QA Scribe (Eli) | 1 | OPS-009 | Refreshing runbook evidence |
+| Codex Agent (Automation) | 1 | OPS-011 ✅ | Guardrail audit complete |
+
+## 🔗 Dependency Graph
+| From | → | To | Rationale |
+|------|---|----|-----------|
+| OPS-001 SigNoz Parser Error Resolution | → | OPS-002 Parser Regression Monitoring | Don’t ship monitoring until parser is healthy |
+| OPS-001 SigNoz Parser Error Resolution | → | OPS-004 Observability Pipeline Implementation | Parser fix feeds pipeline validation |
+| OPS-004 Observability Pipeline Implementation | → | OPS-006 ECRR Task Alignment Analysis | Alignment requires live pipeline data |
+| OPS-003A Framework Scaffolding | → | OPS-003B Framework Guardrails Rollout | Guardrails follow the core framework |
+| OPS-003A Framework Scaffolding | → | OPS-005 Ledger Management Automation | Ledger ingest relies on canonical task schema |
+| OPS-003A Framework Scaffolding | → | OPS-007 INDEX Management Rotation | Index routines use framework IDs |
+
+## 📋 Task Catalog
+| ID | Title | Priority | Status | Owner | Dependencies | Notes & Artifacts |
+|----|-------|----------|--------|-------|--------------|-------------------|
+| OPS-001 | SigNoz Parser Error Resolution | High | 🚧 In Progress | Observability Engineer | – | See [`RUNBOOKS/sigNoz-parser-resolution.md`](RUNBOOKS/sigNoz-parser-resolution.md) |
+| OPS-002 | Parser Regression Monitoring | High | ⏳ Pending | Observability Duty | OPS-001 | Acceptance in [`RUNBOOKS/parser-regression-monitoring.md`](RUNBOOKS/parser-regression-monitoring.md) |
+| OPS-003A | ECRR Task Generation Framework — Core Scaffolding | High | ⏳ Pending | Automation Engineer | – | Schema + writers baseline; DoD in [`RUNBOOKS/ecrr-task-generation-framework.md`](RUNBOOKS/ecrr-task-generation-framework.md) |
+| OPS-003B | ECRR Task Generation Framework — Rollout & Guardrails | Medium | ⏳ Pending | Automation Engineer | OPS-003A | Covers auto-labels, anti-spam, SLAs |
+| OPS-004 | Observability Pipeline Implementation | High | ⏳ Pending | Observability Engineer | OPS-001 | Pipeline validation unblocked once parser is green |
+| OPS-005 | LEDGER Management Automation | Medium | ✅ Done | Data Steward | OPS-003A | Ledger entries now produced via framework schema |
+| OPS-006 | ECRR Task Alignment Analysis | Medium | ⏳ Pending | Strategy Analyst | OPS-004 | Confirms pipeline feeds align with roadmap |
+| OPS-007 | INDEX Management Rotation | Medium | ⏳ Pending | System Admin | OPS-003A | Rotated off engineer queue per WIP guidance |
+| OPS-008 | SigNoz Dashboard Hardening | Low | ✅ Done | Observability Duty | – | Panels live; thresholds mirrored in alerts |
+| OPS-009 | Incident Runbook Refresh | Low | ⏳ Pending | QA Scribe | – | Ensure RUNBOOKS/ coverage & latest evidence |
+| OPS-010 | Alert Channel Audit | Medium | ⏳ Pending | Observability Duty | – | Validate recipients, silences, runbook links |
+| OPS-011 | Automation Guardrail Audit | Low | ✅ Done | Codex Agent | – | Watchdog + CI guardrail checks completed |
+
+### Epic Spotlight: OPS-003 — ECRR Task Generation Framework
+- **Goal**: Single source for task creation with consistent schema + automated hygiene
+- **Subtasks**:
+  - **OPS-003A** — build canonical IDs, writers, and schema validation harness
+  - **OPS-003B** — enable rollout guardrails (auto-labels, spam protection, SLA enforcement)
+- **Feeds**: OPS-005 Ledger Automation, OPS-007 Index Rotation, downstream reporting
+- **Artifacts**: DoD + verification steps documented in [`RUNBOOKS/ecrr-task-generation-framework.md`](RUNBOOKS/ecrr-task-generation-framework.md)
+
+## ✅ Recently Completed
+- **OPS-005** — Ledger automation wired into new schema; audit trail exported to `artifacts/ledger-sync-20250922.json`
+- **OPS-008** — Dashboard hardening shipped with drift panels + warning bands
+- **OPS-011** — Automation guardrails verified; CI parity report archived in `docs/ECRR_REPORTS/`
+
+## 🧾 Definition of Done by Priority Band
+### High Priority
+- ✅ Linked runbook with acceptance checklist
+- ✅ Automated test / verification script executed with evidence attached
+- ✅ Impact metrics (KPI set below) captured before & after change
+- ✅ Rollback plan documented or referenced
+
+### Medium Priority
+- ✅ Acceptance criteria mapped to measurable checks (manual or automated)
+- ✅ Stakeholder notified / documentation updated
+- ✅ Change logged in ledger/index with framework ID
+
+### Low Priority
+- ✅ Change reviewed for regressions or doc drift
+- ✅ Reference added to relevant runbook or knowledge base
+
+## 📈 KPI Snapshot Targets
+Track these in weekly status pings (see dashboards):
+- **Parser Quality**: `parse_error_rate %`, `dropped_events/min`
+- **Latency**: ingest `p50/p95/p99` (source → query)
+- **Schema Stability**: `new_keys/week`, top drifted fields
+- **Throughput**: events/sec (raw vs parsed), compression ratio
+- **Ops Health**: mean-time-to-ack (MTTA), mean-time-to-repair (MTTR)
+
+## 🗓️ Operational Checklists
+- Daily / Weekly / Monthly routines captured in [`RUNBOOKS/operational-checklists.md`](RUNBOOKS/operational-checklists.md)
+- Use the daily checklist before reporting KPIs; weekly for backlog hygiene; monthly for resilience drills
+
+## 📝 Next Status Update Template
+1. **Blockers** — top 2
+2. **Delta** — what moved since last report
+3. **KPI Snapshot** — the 5 metrics above (pass/fail)
+4. **Decision Needed** — optional; frame with 2 options
+
+_ECRR mantra honoured: Examine → Clean → Report → Role._


### PR DESCRIPTION
## Summary
- rebuild TASKS.md as a single source of truth with WIP limits, dependency links, and merged monitoring items
- add runbook-backed definitions of done for parser repair, regression monitoring, and the ECRR task framework
- publish daily/weekly/monthly operational checklists alongside the board

## Testing
- not run (docs-only change)

## ✅ ECRR Gate
- **Examine** — Identified duplicate monitoring/framework tasks and overloaded ownership in the prior board
- **Clean** — Collapsed duplicates, reassigned WIP, and introduced runbooks with explicit acceptance criteria
- **Report** — Updated TASKS.md plus new RUNBOOKS/ documentation for DoD and checklists
- **Role** — Observability Copilot


------
https://chatgpt.com/codex/tasks/task_e_68d461d3c0c8832a904d174c43cc2eb0