### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/signoz-automation.yml
+++ b/.github/workflows/signoz-automation.yml
@@ -1,4 +1,7 @@
 name: SigNoz Automation
+permissions:
+  contents: read
+  actions: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/MoneyCat-inc/otel-ops-pack/security/code-scanning/2](https://github.com/MoneyCat-inc/otel-ops-pack/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow file. The optimal place is at the root level, applying it to all jobs, unless fine-grained permissions are needed for different jobs. Since this workflow only needs to check out source code (`actions/checkout`), upload artifacts (`actions/upload-artifact`), and access repository contents for reading, it does not require write access to the repository. For uploading artifacts, `actions: write` is required, and for accessing repository code, `contents: read` is required. Thus, you should add:

```yaml
permissions:
  contents: read
  actions: write
```

at line 2, right after the `name` field and before the `on:` block. No new imports or code methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
