### PR TITLE
docs(ops): add drive, docker, and quicksuggest maintenance guides

### DIFF
--- a/docs/DRIVE_CLEANUP_FOR_WINDOWS_UPDATE.md
+++ b/docs/DRIVE_CLEANUP_FOR_WINDOWS_UPDATE.md
@@ -1,0 +1,77 @@
+# Drive cleanup for Windows 11 update
+
+Scan showed **Docker is ~202 GB** on C:. Other targets: Windows Update cache (~5 GB), Package Cache (~4 GB), user caches.
+
+## Summary: What to run
+
+| Action | Frees | How |
+|--------|--------|-----|
+| **Docker WSL reset** | **~202 GB** | Run `scripts\reset-docker-wsl-free-space.ps1` **as Administrator** (see below). |
+| **Windows Update cache** | ~5 GB | Run `scripts\free-drive-space-admin.ps1` **as Administrator**. |
+| **Storage / Disk Cleanup** | Variable | Settings → System → Storage → Temporary files → Remove files. Or run `cleanmgr` as admin and select all. |
+| **Package Cache** | ~4 GB | After admin script, or: Disk Cleanup → Clean up system files → check "Windows Update Cleanup". |
+
+---
+
+## 1. Reduce Docker footprint by ~50% (actually ~100% → fresh disk)
+
+Docker data is **~202 GB** in `C:\Users\fubum\AppData\Local\Docker\wsl\disk\docker_data.vhdx`.  
+Docker is not running correctly, so the only way to free this space is to **reset Docker’s WSL data**. That deletes all images, containers, and volumes and frees the whole disk; next start creates a new, small disk.
+
+**Steps:**
+
+1. **Right‑click PowerShell → Run as administrator.**
+2. **Run:**
+   ```powershell
+   Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+   cd c:\otel\scripts
+   .\reset-docker-wsl-free-space.ps1
+   ```
+3. When prompted, type **YES** and press Enter.
+4. After it finishes, start **Docker Desktop**. It will create a new small `docker_data.vhdx` (a few GB). You can pull images again as needed.
+
+**Result:** ~202 GB freed; Docker footprint effectively reduced by 100% (then grows again as you use it).
+
+---
+
+## 2. Windows and system cleanups (~5–10+ GB)
+
+**Run the admin cleanup script (Windows Update cache, Delivery Optimization, Windows Temp):**
+
+1. **Right‑click PowerShell → Run as administrator.**
+2. **Run:**
+   ```powershell
+   Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+   cd c:\otel\scripts
+   .\free-drive-space-admin.ps1
+   ```
+
+**Then use Storage / Disk Cleanup for more:**
+
+- **Settings → System → Storage → Temporary files** → select all → **Remove files**.
+- Or open **Disk Cleanup** (`cleanmgr`) as admin → **Clean up system files** → select **Windows Update Cleanup**, Temporary files, etc. → OK.
+
+---
+
+## 3. Optional: More space (advanced)
+
+- **Hibernation:** If you don’t need hibernation, run in **Admin CMD**:  
+  `powercfg /h off`  
+  That removes `hiberfil.sys` (often several GB). To turn it back on: `powercfg /h on`.
+- **Package Cache (e.g. ~4 GB):** Often under `C:\ProgramData\Package Cache`. Disk Cleanup “Windows Update Cleanup” and “Temporary files” can clear some of it; deleting the folder by hand can break future repair/uninstall of some apps, so prefer Disk Cleanup.
+
+---
+
+## Drive scan results (reference)
+
+| Location | Size (approx) |
+|----------|----------------|
+| `C:\Users\fubum\AppData\Local\Docker` | **201.64 GB** |
+| `C:\Windows\SoftwareDistribution` | 5.24 GB |
+| `C:\Windows\SoftwareDistribution\Download` | 5.17 GB |
+| `C:\ProgramData\Package Cache` | 4.33 GB |
+| `C:\ProgramData\Microsoft` | 12.36 GB |
+| `C:\Users\fubum\AppData\Local\pnpm` | 0.66 GB |
+| User Temp, Recycle Bin | (already cleaned) |
+
+Largest single win: **Docker WSL reset (~202 GB)**. Then **admin script + Storage/Disk Cleanup** for another **~5–10+ GB**.

--- a/docs/QUICKSUGGEST_AMP_SQL_EXPLAINED.md
+++ b/docs/QUICKSUGGEST_AMP_SQL_EXPLAINED.md
@@ -1,0 +1,160 @@
+# Understanding `quicksuggest-amp.sql`
+
+This file is Firefox’s **local SQLite database** for the **Quick Suggest (AMP)** Remote Settings collection. It stores everything Firefox has downloaded from Mozilla’s servers for address-bar suggestions and sponsored suggestions.
+
+---
+
+## What it is
+
+- **Path:**  
+  `C:\Users\fubum\AppData\Local\Mozilla\Firefox\Profiles\fyoi34av.default-release\remote-settings\quicksuggest-amp.sql`
+- **Format:** SQLite 3 database (~944 MB on disk).
+- **Purpose:** Cache for the **quicksuggest-amp** Remote Settings collection: the data that powers **Quick Suggest** in the address bar (suggested sites and sponsored suggestions, including “AMP” / ad-sponsored suggestions).
+
+Firefox fetches this collection from:
+
+`https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/quicksuggest-amp`
+
+and stores it in this SQLite file so it can use it offline and avoid re-downloading on every startup.
+
+---
+
+## Schema (3 tables)
+
+### 1. `collection_metadata` (1 row)
+
+Describes the collection itself:
+
+- **collection_url** – Remote Settings URL for `quicksuggest-amp`.
+- **last_modified** – Timestamp (ms) when the collection was last updated (e.g. `1769884198498`).
+- **bucket** – `"main"`.
+- **signature**, **x5u** – Crypto material so Firefox can verify the data came from Mozilla.
+
+So this table answers: “Which collection is this, when was it last updated, and how do we verify it?”
+
+---
+
+### 2. `records` (177 rows)
+
+Each row is **one record** in the Remote Settings sense: a small JSON blob that describes *what* to show and *where* the real payload lives.
+
+- **id** – Record ID. You’ll see:
+  - **icon-*** (hash or number) – Icons (e.g. favicons) for suggestions.
+  - **sponsored-suggestions-{country}-{form_factor}** – e.g. `sponsored-suggestions-pl-phone`, `sponsored-suggestions-us-desktop`. One record per locale/device type.
+- **collection_url** – Same collection URL as above.
+- **data** – BLOB: JSON for that record.
+
+**Example `data` (one record):**
+
+```json
+{
+  "id": "sponsored-suggestions-pl-phone",
+  "last_modified": 1748541659623,
+  "deleted": false,
+  "attachment": {
+    "filename": "sponsored-suggestions-pl-phone.json",
+    "mimetype": "application/json",
+    "location": "main-workspace/quicksuggest-amp/90d2e045-f14b-423d-950c-f80954fd3164.json",
+    "hash": "...",
+    "size": 1897
+  },
+  "type": "amp",
+  "schema": 1748541656595,
+  "country": "PL",
+  "form_factor": "phone",
+  "filter_expression": "env.country == 'PL' && env.formFactor == 'phone'"
+}
+```
+
+So **records** are the index: “For country X and form factor Y, the actual suggestion list is in the attachment at this `location`.” The real bulk data is in **attachments**.
+
+---
+
+### 3. `attachments` (268 rows) — where the size comes from
+
+Each row is **one attachment**: the actual file (JSON, image, etc.) that a record points to.
+
+- **id** – Path-like ID, e.g. `main-workspace/quicksuggest-amp/5abd0323-9a8d-46e0-879f-de89c3407bb5.json`.
+- **collection_url** – Same collection URL.
+- **data** – BLOB: the full file content (JSON text or image bytes).
+
+**Breakdown of your 268 attachments:**
+
+| Type   | Count | Role |
+|--------|-------|------|
+| **.json** | 104 | Suggestion lists (per country/form factor). One JSON = one big array of suggestions/ads. |
+| **.jpg**  | 90  | Icons/images for suggestions. |
+| **.png**  | 74  | Icons/images for suggestions. |
+
+The **large** attachments are the **.json** files. One of them (for one locale/segment) can be ~14 MB. That JSON is a **single array of thousands of suggestion objects** (one per ad/suggestion).
+
+**Example: one item inside a large JSON array**
+
+The big JSON files are **root = array** of suggestion objects. Each object looks conceptually like:
+
+```json
+{
+  "advertiser": "Amazon",
+  "click_url": "https://bridge.pdx1.admarketplace.net/ctp?...",
+  "full_keywords": [["amazon", 4]],
+  "iab_category": "22 - Shopping",
+  "serp_categories": "...",
+  "icon": "...",
+  "id": "...",
+  "impression_url": "...",
+  "keywords": "...",
+  "score": ...,
+  "title": "...",
+  "url": "..."
+}
+```
+
+So:
+
+- **records** = “Use this attachment for country X, phone/desktop.”
+- **attachments** = The actual files: either **big JSON arrays** (one array per locale/segment, each with thousands of `advertiser`/`click_url`/`title`/`url`/… entries) or **images** (icons).
+
+---
+
+## Why the file is ~1 GB
+
+- **records:** 177 rows, total `data` size is tiny (~81 KB). They’re just metadata + pointer to an attachment.
+- **attachments:** 268 rows, total `data` ~1 GB:
+  - **104 JSON files** – Many are multi‑MB each (one sampled file has **6,935 items** in a single array). So you have many locales/segments × large arrays of suggestions/ads.
+  - **90 JPG + 74 PNG** – Icon/image blobs; smaller than the JSON but still add up.
+
+So the size is **by design**: Firefox is storing the full Quick Suggest/AMP catalog (all locales and form factors) plus all referenced icons. The fact that it’s ~1 GB means Mozilla is shipping a large catalog and your client is caching it all in this one SQLite file.
+
+---
+
+## How Firefox uses it
+
+1. **Remote Settings** client in Firefox periodically (or on demand) fetches the **quicksuggest-amp** collection from Mozilla.
+2. Server sends **records** (the index) and **attachments** (the JSON lists and images).
+3. Firefox stores them in **quicksuggest-amp.sql** (this file).
+4. When you type in the **address bar**, Firefox:
+   - Uses your locale and device type (e.g. US, desktop).
+   - Finds the matching **records** (e.g. `sponsored-suggestions-us-desktop`).
+   - Loads the **attachment** (the big JSON) for that record.
+   - Filters/search that list by keywords and shows **Quick Suggest** / sponsored suggestions.
+
+So this file is the **local mirror** of the Quick Suggest/AMP dataset that powers those address-bar suggestions.
+
+---
+
+## Summary
+
+| Piece | What it is |
+|-------|------------|
+| **File** | SQLite DB for the **quicksuggest-amp** Remote Settings collection. |
+| **collection_metadata** | Who/what/when: collection URL, last modified, verification (signature, x5u). |
+| **records** | Index: 177 entries (icons + one “sponsored-suggestions-{country}-{form_factor}” per segment), each pointing to an attachment. |
+| **attachments** | 268 blobs: 104 big JSON arrays (suggestion lists), 90 JPG, 74 PNG (icons). |
+| **Big JSONs** | Root = array of thousands of objects; each object = one ad/suggestion (advertiser, click_url, title, url, keywords, icon, etc.). |
+| **Why ~1 GB** | Full cached catalog: many locales × large suggestion arrays + all icons. |
+
+If you want to re-inspect it yourself, you can use the script:
+
+`c:\otel\scripts\inspect_quicksuggest.py`
+
+It prints schema, sample records, and a sample suggestion object from a large JSON attachment.

--- a/docs/runbooks/misc/docker-fix-steps.md
+++ b/docs/runbooks/misc/docker-fix-steps.md
@@ -1,0 +1,63 @@
+# Docker Desktop failing to start – fix steps
+
+## What’s going on
+- **Privileged helper service** is not running (Docker needs admin to start it).
+- **Engine never finishes starting** (stuck “starting”, HTTP 500 on _ping).
+- **docker-desktop-data** is missing from `wsl -l -v`; the data disk may be broken after VHDX compact.
+
+---
+
+## Step 1: Use Docker’s “Start service” (elevated)
+
+1. Open **Docker Desktop**.
+2. When the dialog says **“Privileged helper service is not running”**, click **“Start service”**.
+3. Approve the **UAC (admin)** prompt.
+4. Wait for Docker to finish starting.
+
+If the engine still never becomes ready, go to Step 2.
+
+---
+
+## Step 2: Restart Docker service as admin
+
+1. **Quit Docker Desktop** (tray icon → Quit).
+2. Open **PowerShell as Administrator** and run:
+
+```powershell
+Restart-Service com.docker.service -Force
+Start-Process "C:\Program Files\Docker\Docker\Docker Desktop.exe"
+```
+
+3. Wait 1–2 minutes and see if Docker shows “Engine running”.
+
+If it’s still stuck, go to Step 3.
+
+---
+
+## Step 3: Reset WSL Docker distros (fixes broken data disk)
+
+This **deletes all images, containers, and volumes** and lets Docker create a new data disk. Only do this if you’re OK losing that data.
+
+1. **Quit Docker Desktop** (tray → Quit).
+2. Open **PowerShell or CMD as Administrator**:
+
+```powershell
+wsl --shutdown
+wsl --unregister docker-desktop
+wsl --unregister docker-desktop-data
+```
+
+3. Start **Docker Desktop** again. It will recreate `docker-desktop` and `docker-desktop-data` and a new `docker_data.vhdx`.
+4. Wait for the first start to finish (can take a few minutes).
+
+After this, Docker should start normally. The new VHDX will be small and will grow again as you use Docker. To avoid it growing too much in the future:
+
+- Regularly run: `docker system prune -a -f` (and optionally `docker volume prune -f`).
+- Then quit Docker, run `wsl --shutdown`, and compact the VHDX (as before) **only when you’re sure the compact completed successfully**.
+
+---
+
+## If you still see “Privileged helper service” after Step 3
+
+- Run **Docker Desktop** once by **right‑click → Run as administrator**.
+- Or repair/reinstall Docker Desktop from **Settings → Apps → Docker Desktop → Modify/Repair**.

--- a/scripts/analyze-sqlite.ps1
+++ b/scripts/analyze-sqlite.ps1
@@ -1,0 +1,30 @@
+$py = @'
+import sqlite3
+import os
+path = r"C:\Users\fubum\AppData\Local\Mozilla\Firefox\Profiles\fyoi34av.default-release\remote-settings\quicksuggest-amp.sql"
+conn = sqlite3.connect(path)
+cur = conn.cursor()
+cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+tables = [r[0] for r in cur.fetchall()]
+print("Tables:", tables)
+for t in tables:
+    cur.execute("SELECT COUNT(*) FROM [" + t + "]")
+    n = cur.fetchone()[0]
+    cur.execute("PRAGMA table_info(["+ t + "])")
+    cols = cur.fetchall()
+    print("  %s: %d rows, columns: %s" % (t, n, [c[1] for c in cols]))
+    if n > 0 and n <= 5:
+        cur.execute("SELECT * FROM [" + t + "] LIMIT 2")
+        for row in cur.fetchall():
+            print("    sample:", row[:3] if len(row) > 3 else row)
+cur.execute("PRAGMA page_count")
+pages = cur.fetchone()[0]
+cur.execute("PRAGMA page_size")
+ps = cur.fetchone()[0]
+print("Pages: %d, page_size: %d -> logical ~%.1f MB" % (pages, ps, pages*ps/1024/1024))
+cur.execute("PRAGMA freelist_count")
+free = cur.fetchone()[0]
+print("Freelist pages (reclaimable):", free)
+conn.close()
+'@
+$py | python 2>&1

--- a/scripts/analyze_quicksuggest_db.py
+++ b/scripts/analyze_quicksuggest_db.py
@@ -1,0 +1,27 @@
+import sqlite3
+path = r"C:\Users\fubum\AppData\Local\Mozilla\Firefox\Profiles\fyoi34av.default-release\remote-settings\quicksuggest-amp.sql"
+conn = sqlite3.connect(path)
+cur = conn.cursor()
+cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+tables = [r[0] for r in cur.fetchall()]
+print("Tables:", tables)
+for t in tables:
+    cur.execute("SELECT COUNT(*) FROM [%s]" % t)
+    n = cur.fetchone()[0]
+    cur.execute("PRAGMA table_info([%s])" % t)
+    cols = cur.fetchall()
+    print("  %s: %d rows, columns: %s" % (t, n, [c[1] for c in cols]))
+    if n > 0:
+        cur.execute("SELECT * FROM [%s] LIMIT 2" % t)
+        for row in cur.fetchall():
+            preview = str(row)[:120] + "..." if len(str(row)) > 120 else str(row)
+            print("    sample: %s" % preview)
+cur.execute("PRAGMA page_count")
+pages = cur.fetchone()[0]
+cur.execute("PRAGMA page_size")
+ps = cur.fetchone()[0]
+cur.execute("PRAGMA freelist_count")
+free = cur.fetchone()[0]
+print("Pages: %d, page_size: %d -> logical ~%.1f MB" % (pages, ps, pages*ps/1024/1024))
+print("Freelist pages (reclaimable): %d (~%.1f MB)" % (free, free*ps/1024/1024))
+conn.close()

--- a/scripts/free-drive-space-admin.ps1
+++ b/scripts/free-drive-space-admin.ps1
@@ -1,0 +1,46 @@
+#Requires -RunAsAdministrator
+# Free drive space: Windows Update cache, optional Docker WSL reset.
+# Run: PowerShell -ExecutionPolicy Bypass -File "c:\otel\scripts\free-drive-space-admin.ps1"
+
+$ErrorActionPreference = 'Stop'
+
+# --- 1. Windows Update cache (~5 GB) ---
+Write-Host "Stopping Windows Update services..."
+$svc = @('wuauserv', 'bits', 'cryptSvc', 'msiserver')
+foreach ($s in $svc) {
+    try { Stop-Service -Name $s -Force -ErrorAction SilentlyContinue } catch {}
+}
+Start-Sleep -Seconds 2
+
+$downloadPath = "C:\Windows\SoftwareDistribution\Download"
+$dataStorePath = "C:\Windows\SoftwareDistribution\DataStore"
+if (Test-Path $downloadPath) {
+    $before = (Get-ChildItem $downloadPath -Recurse -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum
+    Get-ChildItem $downloadPath -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    Write-Host "Cleared Windows Update Download cache (freed ~$([math]::Round($before/1GB,2)) GB)"
+}
+if (Test-Path $dataStorePath) {
+    Get-ChildItem $dataStorePath -Exclude "*.edb" -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Starting Windows Update services..."
+foreach ($s in $svc) {
+    try { Start-Service -Name $s -ErrorAction SilentlyContinue } catch {}
+}
+
+# --- 2. Delivery Optimization cache (if present) ---
+$doPath = "$env:SystemRoot\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\Cache"
+if (Test-Path $doPath) {
+    $size = (Get-ChildItem $doPath -Recurse -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum
+    Get-ChildItem $doPath -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    Write-Host "Cleared Delivery Optimization cache (freed ~$([math]::Round($size/1MB,2)) MB)"
+}
+
+# --- 3. Windows Temp ---
+if (Test-Path "C:\Windows\Temp") {
+    Get-ChildItem "C:\Windows\Temp" -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    Write-Host "Cleared C:\Windows\Temp"
+}
+
+Write-Host "Admin cleanup done. For Docker reset (~202 GB), run: .\reset-docker-wsl-free-space.ps1"
+Write-Host "Then run Windows Update again to re-download the update."

--- a/scripts/inspect_quicksuggest.py
+++ b/scripts/inspect_quicksuggest.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""Inspect Firefox quicksuggest-amp.sql - schema and content."""
+import sqlite3
+import json
+import os
+
+path = r"C:\Users\fubum\AppData\Local\Mozilla\Firefox\Profiles\fyoi34av.default-release\remote-settings\quicksuggest-amp.sql"
+conn = sqlite3.connect(path)
+cur = conn.cursor()
+
+print("=" * 60)
+print("SCHEMA (CREATE TABLE)")
+print("=" * 60)
+cur.execute("SELECT name, sql FROM sqlite_master WHERE type='table' ORDER BY name")
+for name, sql in cur.fetchall():
+    print(sql)
+    print()
+
+print("=" * 60)
+print("COLLECTION_METADATA (what this collection is)")
+print("=" * 60)
+cur.execute("SELECT * FROM collection_metadata")
+row = cur.fetchone()
+print("collection_url:", row[0])
+print("last_modified:", row[1], "(timestamp ms)")
+print("bucket:", row[2])
+print("signature (first 60):", (row[3] or b"")[:60])
+print("x5u (first 60):", (row[4] or b"")[:60] if row[4] else None)
+
+print("\n" + "=" * 60)
+print("RECORDS table – what kinds of records")
+print("=" * 60)
+cur.execute("SELECT id FROM records ORDER BY id LIMIT 20")
+ids = [r[0] for r in cur.fetchall()]
+for i in ids:
+    print(" ", i)
+cur.execute("SELECT id FROM records")
+all_ids = [r[0] for r in cur.fetchall()]
+print("  ... total unique record ids:", len(all_ids))
+
+# One record's data - decode if bytes
+cur.execute("SELECT id, data FROM records WHERE id LIKE 'sponsored%' LIMIT 1")
+row = cur.fetchone()
+if row:
+    print("\n  Example record id:", row[0])
+    data = row[1]
+    if isinstance(data, bytes):
+        data = data.decode("utf-8", errors="replace")
+    try:
+        j = json.loads(data)
+        print("  data keys:", list(j.keys()))
+        print("  data sample:", json.dumps(j, indent=2)[:600])
+    except Exception as e:
+        print("  data (first 300 chars):", data[:300])
+
+print("\n" + "=" * 60)
+print("ATTACHMENTS table – types and sizes")
+print("=" * 60)
+cur.execute("SELECT id, length(data) FROM attachments ORDER BY length(data) DESC")
+rows = cur.fetchall()
+extensions = {}
+for aid, size in rows:
+    ext = os.path.splitext(aid)[1].lower() or "(no ext)"
+    extensions[ext] = extensions.get(ext, 0) + 1
+print("  By file extension:", extensions)
+print("  Total attachments:", len(rows))
+print("  Largest 3:", rows[:3])
+
+# One large JSON attachment (the big ones are .json)
+cur.execute("SELECT id, data FROM attachments WHERE id LIKE '%.json' ORDER BY length(data) DESC LIMIT 1")
+row = cur.fetchone()
+if row:
+    print("\n  Example LARGE JSON attachment id:", row[0])
+    data = row[1]
+    if isinstance(data, bytes):
+        data = data.decode("utf-8", errors="replace")
+    try:
+        j = json.loads(data)
+        if isinstance(j, list):
+            print("  Root: LIST of %d items (one ad/suggestion per item)" % len(j))
+            if len(j) > 0:
+                print("  First item keys:", list(j[0].keys()))
+                print("  First item sample:", json.dumps(j[0], indent=2)[:1200])
+        else:
+            print("  Top-level keys:", list(j.keys()))
+            for k in list(j.keys())[:8]:
+                v = j[k]
+                if isinstance(v, list):
+                    print("    %s: list len=%d" % (k, len(v)))
+                    if len(v) > 0:
+                        print("      first item keys:", list(v[0].keys()) if isinstance(v[0], dict) else type(v[0]))
+                elif isinstance(v, dict):
+                    print("    %s: dict keys=%s" % (k, list(v.keys())[:5]))
+                else:
+                    print("    %s: %s" % (k, type(v).__name__))
+    except Exception as e:
+        print("  parse error:", e)
+        print("  first 500 chars:", data[:500])
+
+conn.close()
+print("\nDone.")

--- a/scripts/reset-docker-wsl-free-space.ps1
+++ b/scripts/reset-docker-wsl-free-space.ps1
@@ -1,0 +1,35 @@
+#Requires -RunAsAdministrator
+# Resets Docker WSL data to free ~202 GB. All images, containers, volumes are DELETED.
+# Run only if you need space and are OK losing all Docker data.
+# Run: PowerShell -ExecutionPolicy Bypass -File "c:\otel\scripts\reset-docker-wsl-free-space.ps1"
+# Optional: .\reset-docker-wsl-free-space.ps1 -Force  (skip confirmation)
+
+param([switch]$Force)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $Force) {
+    Write-Host "This will DELETE all Docker images, containers, and volumes and free ~202 GB."
+    Write-Host "Docker Desktop will create a fresh small disk on next start."
+    $confirm = Read-Host "Type YES to continue"
+    if ($confirm -ne 'YES') {
+        Write-Host "Aborted."
+        exit 0
+    }
+}
+
+# Quit Docker Desktop if running
+Get-Process -Name "Docker Desktop" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+Start-Sleep -Seconds 3
+
+Write-Host "Shutting down WSL..."
+wsl --shutdown
+Start-Sleep -Seconds 5
+
+Write-Host "Unregistering docker-desktop..."
+wsl --unregister docker-desktop 2>$null
+
+Write-Host "Unregistering docker-desktop-data (this deletes the ~202 GB VHDX)..."
+wsl --unregister docker-desktop-data 2>$null
+
+Write-Host "Done. ~202 GB freed. Start Docker Desktop to create a new small data disk."

--- a/scripts/shrink-docker-vhdx.ps1
+++ b/scripts/shrink-docker-vhdx.ps1
@@ -1,0 +1,173 @@
+#Requires -RunAsAdministrator
+<#
+.SYNOPSIS
+    Shrink Docker WSL VHDX by pruning unused data and compacting the disk.
+.DESCRIPTION
+    Reduces docker_data.vhdx size by:
+    1. Pruning unused Docker images, containers, volumes, and build cache
+    2. Quitting Docker Desktop and shutting down WSL
+    3. Compacting the VHDX file (Optimize-VHD or diskpart)
+
+    Preserves images/volumes in use by running containers.
+    Target: ~50%+ reduction for a 200GB VHDX.
+.PARAMETER VhdxPath
+    Path to docker_data.vhdx (default: %LOCALAPPDATA%\Docker\wsl\disk\docker_data.vhdx)
+.PARAMETER SkipPrune
+    Skip Docker prune (only compact - use if you already pruned)
+.PARAMETER Force
+    Skip confirmation prompt
+.PARAMETER AfterReboot
+    Compact-only mode: skip Docker steps. Run immediately after reboot, BEFORE starting Docker.
+    Use when the VHDX stays locked (e.g. by vmwp). Ensures no process has the file open.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$VhdxPath = "$env:LOCALAPPDATA\Docker\wsl\disk\docker_data.vhdx",
+    [switch]$SkipPrune,
+    [switch]$Force,
+    [switch]$AfterReboot
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step { param([string]$Msg, [string]$Color = 'Cyan') Write-Host "`n$Msg" -ForegroundColor $Color }
+function Write-Ok { param([string]$Msg) Write-Host "  OK: $Msg" -ForegroundColor Green }
+function Write-Warn { param([string]$Msg) Write-Host "  WARN: $Msg" -ForegroundColor Yellow }
+
+# Resolve path
+$VhdxPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($VhdxPath)
+
+if (-not (Test-Path $VhdxPath)) {
+    Write-Host "VHDX not found: $VhdxPath" -ForegroundColor Red
+    Write-Host "Check Docker Desktop WSL disk location (e.g. wsl\data\ext4.vhdx on older installs)" -ForegroundColor Yellow
+    exit 1
+}
+
+$sizeBefore = (Get-Item $VhdxPath).Length
+$sizeGB = [math]::Round($sizeBefore / 1GB, 2)
+Write-Host "`n== Shrink Docker VHDX ==" -ForegroundColor Cyan
+Write-Host "  Path: $VhdxPath"
+Write-Host "  Current size: $sizeGB GB"
+Write-Host "  Target: ~50% reduction"
+
+if (-not $Force) {
+    Write-Host "`nThis will:"
+    Write-Host "  1. Remove unused Docker images, volumes, build cache (~60-90 GB typical)"
+    Write-Host "  2. Quit Docker Desktop and shut down WSL"
+    Write-Host "  3. Compact the VHDX file"
+    Write-Host "`nRunning containers and their images/volumes will be preserved."
+    $confirm = Read-Host "`nType YES to continue"
+    if ($confirm -ne 'YES') {
+        Write-Host "Aborted." -ForegroundColor Yellow
+        exit 0
+    }
+}
+
+# --- 1. Docker prune ---
+if ($AfterReboot) {
+    Write-Step "1. AfterReboot mode: skipping Docker steps"
+} elseif (-not $SkipPrune) {
+    Write-Step "1. Pruning Docker (unused images, volumes, build cache)..."
+    try {
+        docker system df 2>$null | Out-Host
+        docker system prune -a --volumes -f 2>&1 | Out-Host
+        docker builder prune -a -f 2>&1 | Out-Host
+        Write-Ok "Prune complete"
+    }
+    catch {
+        Write-Warn "Prune failed or Docker not running: $_"
+    }
+}
+else {
+    Write-Step "1. Skipping prune (SkipPrune)"
+}
+
+# --- 2. Quit Docker Desktop ---
+if ($AfterReboot) {
+    Write-Step "2. AfterReboot: skipping (Docker not started)"
+} else {
+    Write-Step "2. Quitting Docker Desktop..."
+    Get-Process -Name "Docker Desktop" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 5
+    Write-Ok "Docker Desktop stopped"
+}
+
+# --- 3. Shut down WSL ---
+Write-Step "3. Shutting down WSL..."
+wsl --shutdown
+Write-Host "  Waiting 30s for WSL to release VHDX..." -ForegroundColor Gray
+Start-Sleep -Seconds 30
+# WSL/Hyper-V processes that can hold the VHDX lock
+$wslProcs = @('vmwp', 'wslhost', 'wslservice', 'vmmem')
+foreach ($proc in $wslProcs) {
+    $p = Get-Process $proc -ErrorAction SilentlyContinue
+    if ($p) {
+        Write-Host "  Stopping $proc.exe to release lock..." -ForegroundColor Gray
+        $p | Stop-Process -Force -ErrorAction SilentlyContinue
+    }
+}
+if (Get-Process vmwp, wslhost, wslservice, vmmem -ErrorAction SilentlyContinue) {
+    Start-Sleep -Seconds 10
+}
+Write-Ok "WSL shut down"
+
+# --- 4. Compact VHDX ---
+Write-Step "4. Compacting VHDX (this may take several minutes)..."
+
+$compactOk = $false
+
+# Try Optimize-VHD (Windows Pro/Enterprise with Hyper-V), retry if file locked
+if (Get-Command Optimize-VHD -ErrorAction SilentlyContinue) {
+    foreach ($attempt in 1..3) {
+        try {
+            Optimize-VHD -Path $VhdxPath -Mode Full
+            $compactOk = $true
+            Write-Ok "Optimize-VHD completed"
+            break
+        } catch {
+            Write-Warn "Optimize-VHD attempt $attempt failed: $_"
+            if ($attempt -lt 3) {
+                Write-Host "  Waiting 30s before retry..." -ForegroundColor Gray
+                Start-Sleep -Seconds 30
+            }
+        }
+    }
+}
+
+# Fallback: diskpart (works on Windows Home)
+if (-not $compactOk) {
+    $diskpartScript = "select vdisk file=`"$VhdxPath`"`nattach vdisk readonly`ncompact vdisk`ndetach vdisk`nexit`n"
+    $scriptPath = Join-Path $env:TEMP "diskpart_shrink_$(Get-Random).txt"
+    [System.IO.File]::WriteAllText($scriptPath, $diskpartScript, [System.Text.Encoding]::ASCII)
+    try {
+        diskpart /s $scriptPath
+        $compactOk = $true
+        Write-Ok "diskpart compact completed"
+    }
+    catch {
+        Write-Warn "diskpart compact failed: $_"
+    }
+    finally {
+        Remove-Item $scriptPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if (-not $compactOk) {
+    Write-Host "  Failed to compact VHDX (file locked). Try:" -ForegroundColor Yellow
+    Write-Host "  1. Reboot, then run BEFORE starting Docker:" -ForegroundColor Gray
+    Write-Host "     .\shrink-docker-vhdx.ps1 -AfterReboot -Force" -ForegroundColor Gray
+    Write-Host "  2. Or run manually as Admin after reboot: Optimize-VHD -Path '$VhdxPath' -Mode Full" -ForegroundColor Gray
+}
+
+# --- Summary ---
+$sizeAfter = (Get-Item $VhdxPath).Length
+$sizeAfterGB = [math]::Round($sizeAfter / 1GB, 2)
+$freedGB = [math]::Round(($sizeBefore - $sizeAfter) / 1GB, 2)
+$pct = if ($sizeBefore -gt 0) { [math]::Round(100 * ($sizeBefore - $sizeAfter) / $sizeBefore, 1) } else { 0 }
+
+Write-Host "`n== Result ==" -ForegroundColor Cyan
+Write-Host "  Before: $sizeGB GB"
+Write-Host "  After:  $sizeAfterGB GB"
+Write-Host "  Freed:  $freedGB GB ($pct% reduction)" -ForegroundColor $(if ($pct -ge 50) { 'Green' } else { 'Yellow' })
+Write-Host "`nStart Docker Desktop to resume. VHDX will grow again as you use Docker." -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
Adds Windows/Docker maintenance runbooks and companion scripts:
- `docs/DRIVE_CLEANUP_FOR_WINDOWS_UPDATE.md`
- `docs/QUICKSUGGEST_AMP_SQL_EXPLAINED.md`
- `docs/runbooks/misc/docker-fix-steps.md`
- Admin scripts for drive cleanup, Docker WSL reset, VHDX shrink, SQLite analysis

## Test plan
- [x] Doc and script additions only
- [ ] Admin scripts require elevation when run locally
