### PR TITLE
docs: refresh README and fix documentation hub links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,24 +5,25 @@
 [![CodeQL](https://github.com/MoneyCat-inc/otel-ops-pack/actions/workflows/codeql.yml/badge.svg)](https://github.com/MoneyCat-inc/otel-ops-pack/actions/workflows/codeql.yml)
 [![Maintained by MoneyCat-inc](https://img.shields.io/badge/Maintained%20by-MoneyCat--inc-00aa88?style=for-the-badge&logo=github&logoColor=white)](https://github.com/MoneyCat-inc)
 
-**OpenTelemetry observability pipeline** feeding Windows Event Logs and file logs directly into **SigNoz** for real-time monitoring. Optimized for low latency (200ms batches) with noise filtering (~50% volume reduction).
+**OpenTelemetry observability pipeline** feeding Windows Event Logs and file logs into **SigNoz** for real-time monitoring. Optimized for low latency (200ms batches) with noise filtering (~50% volume reduction).
 
 ---
 
 ## 🚀 Quick Start
 
-**Professional site rebuild (2025-10-07)** unified all navigation and documentation.
+### 📚 Start Here
+👉 **[Documentation Hub](docs/index.html)** — main entry point  
+👉 **[Canonical References Map](docs/status/REFERENCES_MAP.md)** — single source of truth for working parts  
+👉 **[Repository Index (AGENTS.md)](AGENTS.md)** — governance and agent entry point
 
-### 📚 **Start Here**
-👉 **[Documentation Hub](docs/index.html)** — Your main entry point  
-👉 **[Canonical References Map](docs/status/REFERENCES_MAP.md)** — Single source of truth for all working parts
+### 🎛️ Live Dashboards
+- **[Status Dashboard](docs/status.html)** — real-time metrics and system health
+- **[Executive Status](docs/status/misc/STATUS.md)** — gate, SBOM, and pipeline summary
 
-### 🎛️ **Live Dashboards**
-- **[Status Dashboard](docs/status.html)** — Real-time metrics and system health
-
-### 📊 **Key Resources**
+### 📊 Key Resources
 - **[Gate Archive (2025-10)](docs/gate/2025-10/)** — October 2025 gate verification evidence
-- **[Security Master Guide](docs/BossCat/SECURITY_MAINTENANCE_MASTER_GUIDE.md)** — Security and maintenance procedures
+- **[Security Master Guide](docs/BossCat/SECURITY_MAINTENANCE_MASTER_GUIDE.md)** — security and maintenance procedures
+- **[Windows Collector Runbook](docs/runbooks/windows-collector.md)** — OTLP ports and service config
 
 ---
 
@@ -49,7 +50,10 @@ A **small, evidence-first** Windows observability pack:
 - **PowerShell 7+** (monitoring scripts)
 - **Docker** (SigNoz stack)
 - **SigNoz UI:** http://localhost:8080
-- **OTLP Endpoints:** 5317 (gRPC), 5318 (HTTP)
+- **OTLP ingest (Windows collector):** 5317 (gRPC), 5318 (HTTP)
+- **OTLP export (collector → SigNoz):** localhost:4317
+
+See [windows/otelcol/README.md](windows/otelcol/README.md) for canonical service configuration.
 
 ---
 
@@ -58,33 +62,28 @@ A **small, evidence-first** Windows observability pack:
 [![Patreon](https://img.shields.io/badge/Support-Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/c/FaeMcLachlan)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/fubumaki)
 
-Help fund development of BossCat automation lanes, deeper SigNoz playbooks, and the anti-clickbait transparency hub. Every contribution supports evidence-first observability infrastructure.
-
-**Sponsorship Tiers:**
-- **🐱 Comfort Cat** ($5/mo) — Early access to new features
-- **🦁 BossCat Tier** ($15/mo) — Priority support + quarterly roadmap input
-- **🐯 Executive Tier** ($50/mo) — All benefits + monthly 1:1 consultation
+Help fund BossCat automation lanes, SigNoz playbooks, and the anti-clickbait transparency hub.
 
 ---
 
 ## 📖 Documentation
 
-All documentation is centralized in the **[Documentation Hub](docs/index.html)** with the **[Canonical References Map](docs/status/REFERENCES_MAP.md)** serving as the single source of truth.
+All documentation is centralized in the **[Documentation Hub](docs/index.html)** with the **[Canonical References Map](docs/status/REFERENCES_MAP.md)** as the navigation index.
 
 ### Key Documentation Sections
-- **Gate & Readiness** — Production verification procedures
-- **Persona & Governance** — Merge discipline and ECRR methodology  
-- **Stakeholder Evidence** — Executive packages and audit trails
-- **Security & Maintenance** — Security procedures and risk waivers
-- **Dashboards & Data Room** — Live observability interfaces
-- **Bots & Lanes** — AUTO-BOTS registry and lane enforcement
-- **Rebuild History** — Professional site rebuild documentation
+- **Gate & Readiness** — production verification procedures
+- **Persona & Governance** — [Charter](docs/BossCat/CHARTER.md), [Persona v1.1](docs/BossCat/IMMUTABLE_PERSONA_v1.1.md)
+- **Stakeholder Evidence** — executive packages and audit trails
+- **Security & Maintenance** — security procedures and risk waivers
+- **Runbooks** — [Windows collector](docs/runbooks/windows-collector.md), [Docker recovery](docs/runbooks/misc/docker-fix-steps.md)
+- **ECRR Reports** — [complete audit trail](docs/ecrr/ECRR_REPORTS/)
 
 ---
 
 ## 🔐 Security
 
 - **Security scanning:** CodeQL, Gitleaks, Dependabot
+- **SBOM:** blocking on prod gate (see [FOLLOWUP_SBOM_BLOCKING.md](docs/BossCat/FOLLOWUP_SBOM_BLOCKING.md))
 - **Master guide:** [Security & Maintenance](docs/BossCat/SECURITY_MAINTENANCE_MASTER_GUIDE.md)
 - **Error ledger:** [IONA_ERRORS.md](docs/IONA_ERRORS.md)
 
@@ -92,51 +91,52 @@ All documentation is centralized in the **[Documentation Hub](docs/index.html)**
 
 ## 🤝 Contributing
 
-We follow strict **BossCat governance** with immutable merge rules:
+We follow **BossCat governance** with immutable merge rules:
 
 - **Budget enforcement:** ≤10 files, ≤200 LOC per merge
-- **ECRR methodology:** All changes follow Examine → Clean → Report → Role
-- **Gate verification:** Must pass before merge
-- **Kill-switch:** Active for drift control
+- **ECRR methodology:** Examine → Clean → Report → Role
+- **Gate verification:** must pass before merge
+- **Kill-switch:** active for drift control
 
-See: [ECRR Manual](docs/BossCat/misc/ART_OF_ECRR.md) | [Agents & Hierarchy](docs/BossCat/CHARTER.md)
+See: [AGENTS.md](AGENTS.md) | [ECRR Manual](docs/BossCat/misc/ART_OF_ECRR.md) | [Charter](docs/BossCat/CHARTER.md)
 
 ---
 
 ## 📊 Project Status
 
-**System Health:** ✅ 96/100 (Excellent)  
-**Gate Pass Rate:** 96% (78/81 ready)  
-**ECRR Reports:** 195+ comprehensive reports  
-**Active Development:** 11+ consecutive days
+**Last updated:** June 2026 — see [Executive Status](docs/status/misc/STATUS.md) for current gate, SBOM, and pipeline health.
 
-See [Status Dashboard](docs/status.html) for detailed metrics.
+- **Main branch gates:** green (BossCat Gate Verify, CodeQL, Gitleaks)
+- **Local pipeline:** Docker + SigNoz + Windows collector (`quick-monitor` health check)
+- **ECRR reports:** 350+ under `docs/ecrr/ECRR_REPORTS/`
+
+Live metrics: [Status Dashboard](docs/status.html)
 
 ---
 
 ## 🎯 Quick Commands
 
 ```powershell
-# Health check
+# Fast health check
 pwsh BRAV\SCPT\quick-monitor.ps1
 
 # Detailed monitoring
-pwsh scripts/monitor-optimized-pipeline.ps1 -DurationMinutes 10
+pwsh scripts\monitor-optimized-pipeline.ps1 -DurationMinutes 10
 
 # Generate canary test
-pwsh scripts/canary-test.ps1
+pwsh canary-test.ps1
 
-# Verify pipeline
-pwsh scripts/verify-pipeline.ps1
+# Verify pipeline end-to-end
+pwsh verify-pipeline.ps1
 ```
 
 ---
 
 ## 📚 Additional Resources
 
-- **[Cheat Sheets](docs/cheatsheets/README.md)** — Quick reference guides
-- **[ECRR Reports](docs/ecrr/ECRR_REPORTS/)** — Complete audit trail
-- **[Observability Snapshots](docs/observability/snapshots/)** — Dashboard exports
+- **[Cheat Sheets](docs/cheatsheets/README.md)** — quick reference guides
+- **[ECRR Reports](docs/ecrr/ECRR_REPORTS/)** — complete audit trail
+- **[Observability Snapshots](docs/observability/snapshots/)** — dashboard exports
 
 ---
 
@@ -153,11 +153,9 @@ pwsh scripts/verify-pipeline.ps1
 
 **Maintained by:** MoneyCat-inc  
 **Authority:** BossCat OEM (Executive Overseer Manager)  
-**Methodology:** ECRR (Examine → Clean → Report → Role)  
-**Creative Guide:** See Documentation Hub for creative references
+**Methodology:** ECRR (Examine → Clean → Report → Role)
 
-**Professional Site Rebuild:** October 7, 2025  
-Unified navigation, docs hub, and observability interfaces.
+**Site hub:** unified navigation via [docs/index.html](docs/index.html) (rebuilt October 2025, refreshed June 2026).
 
 ---
 

--- a/docs/BossCat/data_room_enhanced.html
+++ b/docs/BossCat/data_room_enhanced.html
@@ -1,0 +1,639 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Resonai Data Room — Test Harness & Chaos Engineering</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<style>
+  :root {
+    --bg: #0b0d12;
+    --card: #121520;
+    --muted: #77809a;
+    --fg: #e9edf7;
+    --green: #4caf50;
+    --yellow: #ffc107;
+    --red: #f44336;
+    --blue: #7c5cff;
+    --teal: #00c2b2;
+    --orange: #f57c00;
+    --border: #252b3a;
+    --gradient-primary: linear-gradient(135deg, #7c5cff 0%, #4caf50 100%);
+  }
+  
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  
+  body {
+    font-family: system-ui, -apple-system, Segoe UI, Roboto, Inter, sans-serif;
+    background: var(--bg);
+    color: var(--fg);
+    line-height: 1.6;
+  }
+  
+  .header {
+    background: var(--gradient-primary);
+    padding: 32px 24px;
+    text-align: center;
+  }
+  
+  .header h1 {
+    font-size: 32px;
+    font-weight: 800;
+    color: white;
+    margin-bottom: 8px;
+    text-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  }
+  
+  .header p {
+    color: rgba(255,255,255,0.9);
+    font-size: 14px;
+  }
+  
+  .container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 24px;
+  }
+  
+  .controls-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+  
+  .btn {
+    padding: 14px 20px;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    color: white;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  }
+  
+  .btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+  }
+  
+  .btn-laminar { background: var(--green); }
+  .btn-laminar:hover { background: #2e7d32; }
+  
+  .btn-chaotic { background: var(--orange); }
+  .btn-chaotic:hover { background: #d84315; }
+  
+  .btn-test { background: var(--blue); }
+  .btn-test:hover { background: #5a3cc4; }
+  
+  .btn-canary { background: var(--teal); }
+  .btn-canary:hover { background: #008c7f; }
+  
+  .btn-stop { background: var(--red); }
+  .btn-stop:hover { background: #b71c1c; }
+  
+  .btn-clear { background: var(--muted); }
+  .btn-clear:hover { background: #5f6679; }
+  
+  .section {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 24px;
+    margin-bottom: 24px;
+  }
+  
+  .section-title {
+    font-size: 18px;
+    font-weight: 700;
+    margin-bottom: 16px;
+    color: var(--fg);
+  }
+  
+  .metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+  
+  .metric-card {
+    background: rgba(255,255,255,0.02);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+  }
+  
+  .metric-label {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--muted);
+    margin-bottom: 8px;
+  }
+  
+  .metric-value {
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--fg);
+  }
+  
+  .metric-value.ok { color: var(--green); }
+  .metric-value.warn { color: var(--yellow); }
+  .metric-value.bad { color: var(--red); }
+  
+  .chart-container {
+    position: relative;
+    height: 300px;
+    margin-top: 16px;
+  }
+  
+  .logs-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  
+  .logs-table th {
+    text-align: left;
+    padding: 10px 12px;
+    border-bottom: 2px solid var(--border);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  
+  .logs-table td {
+    padding: 12px;
+    border-bottom: 1px solid var(--border);
+    font-size: 13px;
+  }
+  
+  .logs-table tr:hover {
+    background: rgba(255,255,255,0.02);
+  }
+  
+  .log-level {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+  }
+  
+  .log-level.INFO { background: rgba(0,194,178,.18); color: var(--teal); }
+  .log-level.WARN { background: rgba(255,193,7,.20); color: var(--yellow); }
+  .log-level.ERROR { background: rgba(244,67,54,.18); color: var(--red); }
+  .log-level.DEBUG { background: rgba(124,92,255,.18); color: var(--blue); }
+  
+  .status-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    background: rgba(76,175,80,.18);
+    border: 1px solid rgba(76,175,80,.35);
+    border-radius: 8px;
+    margin-bottom: 24px;
+  }
+  
+  .status-bar.active { background: rgba(76,175,80,.18); border-color: rgba(76,175,80,.35); }
+  .status-bar.stopped { background: rgba(244,67,54,.18); border-color: rgba(244,67,54,.35); }
+  
+  .status-indicator {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+  }
+  
+  .status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--green);
+    animation: pulse 2s ease-in-out infinite;
+  }
+  
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+  }
+  
+  .chaos-scenarios {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 12px;
+  }
+  
+  .scenario-card {
+    background: rgba(255,255,255,0.02);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+  
+  .scenario-card:hover {
+    border-color: var(--blue);
+    background: rgba(124,92,255,0.1);
+  }
+  
+  .scenario-title {
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+  
+  .scenario-desc {
+    font-size: 12px;
+    color: var(--muted);
+  }
+  
+  .footer {
+    text-align: center;
+    padding: 24px;
+    color: var(--muted);
+    font-size: 12px;
+  }
+  
+  .footer a {
+    color: var(--blue);
+    text-decoration: none;
+  }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>🧪 Resonai Data Room — Test Harness</h1>
+  <p>Chaos Engineering • Load Testing • Signal Generation • BossCat OEM Certified</p>
+</div>
+
+<div class="container">
+
+  <!-- Status Bar -->
+  <div class="status-bar active" id="statusBar">
+    <div class="status-indicator">
+      <span class="status-dot"></span>
+      <span id="statusText">Test Harness Active</span>
+    </div>
+    <div style="font-size: 12px;">
+      Last update: <span id="lastUpdate">--:--:--</span>
+    </div>
+  </div>
+
+  <!-- Primary Controls -->
+  <div class="section">
+    <h2 class="section-title">🎛️ Primary Controls</h2>
+    <div class="controls-grid">
+      <button class="btn btn-laminar" onclick="generateData('laminar')">
+        🌊 Laminar Flow
+      </button>
+      <button class="btn btn-chaotic" onclick="generateData('chaotic')">
+        🌀 Chaotic Flow
+      </button>
+      <button class="btn btn-test" onclick="generateData('test')">
+        🧪 Test Signal
+      </button>
+      <button class="btn btn-canary" onclick="generateData('canary')">
+        🐤 Canary Test
+      </button>
+      <button class="btn btn-stop" onclick="stopData()">
+        🛑 Stop Signals
+      </button>
+      <button class="btn btn-clear" onclick="clearLogs()">
+        🗑️ Clear Logs
+      </button>
+    </div>
+  </div>
+
+  <!-- Real-Time Metrics -->
+  <div class="section">
+    <h2 class="section-title">📊 Real-Time Metrics</h2>
+    <div class="metrics-grid">
+      <div class="metric-card">
+        <div class="metric-label">Throughput</div>
+        <div class="metric-value ok" id="throughput">0</div>
+        <div style="font-size: 12px; color: var(--muted); margin-top: 4px;">req/sec</div>
+      </div>
+      <div class="metric-card">
+        <div class="metric-label">Total Events</div>
+        <div class="metric-value" id="totalEvents">0</div>
+        <div style="font-size: 12px; color: var(--muted); margin-top: 4px;">cumulative</div>
+      </div>
+      <div class="metric-card">
+        <div class="metric-label">Error Rate</div>
+        <div class="metric-value ok" id="errorRate">0%</div>
+        <div style="font-size: 12px; color: var(--muted); margin-top: 4px;">percentage</div>
+      </div>
+      <div class="metric-card">
+        <div class="metric-label">Active Tests</div>
+        <div class="metric-value ok" id="activeTests">0</div>
+        <div style="font-size: 12px; color: var(--muted); margin-top: 4px;">running</div>
+      </div>
+    </div>
+    <div class="chart-container">
+      <canvas id="metricsChart"></canvas>
+    </div>
+  </div>
+
+  <!-- Chaos Engineering Scenarios -->
+  <div class="section">
+    <h2 class="section-title">💥 Chaos Engineering Scenarios</h2>
+    <div class="chaos-scenarios">
+      <div class="scenario-card" onclick="runChaos('network-delay')">
+        <div class="scenario-title">🔌 Network Delay</div>
+        <div class="scenario-desc">Simulate 200-500ms latency</div>
+      </div>
+      <div class="scenario-card" onclick="runChaos('service-down')">
+        <div class="scenario-title">❌ Service Down</div>
+        <div class="scenario-desc">Simulate service unavailability</div>
+      </div>
+      <div class="scenario-card" onclick="runChaos('memory-spike')">
+        <div class="scenario-title">📈 Memory Spike</div>
+        <div class="scenario-desc">Trigger memory pressure</div>
+      </div>
+      <div class="scenario-card" onclick="runChaos('cpu-throttle')">
+        <div class="scenario-title">⚡ CPU Throttle</div>
+        <div class="scenario-desc">Simulate high CPU load</div>
+      </div>
+      <div class="scenario-card" onclick="runChaos('disk-full')">
+        <div class="scenario-title">💾 Disk Full</div>
+        <div class="scenario-desc">Simulate storage exhaustion</div>
+      </div>
+      <div class="scenario-card" onclick="runChaos('packet-loss')">
+        <div class="scenario-title">📦 Packet Loss</div>
+        <div class="scenario-desc">Drop 10% of packets</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Event Logs -->
+  <div class="section">
+    <h2 class="section-title">📋 Event Logs</h2>
+    <table class="logs-table">
+      <thead>
+        <tr>
+          <th>Timestamp</th>
+          <th>Level</th>
+          <th>Source</th>
+          <th>Message</th>
+          <th>Details</th>
+        </tr>
+      </thead>
+      <tbody id="logsBody">
+        <tr>
+          <td colspan="5" style="text-align: center; color: var(--muted); padding: 32px;">
+            No events logged yet. Click a button above to generate test data.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</div>
+
+<div class="footer">
+  <p>🐾 <strong>Resonai [OTel] Test Harness</strong> • BossCat OEM Certified</p>
+  <p>
+    <a href="../../index.html">← Back to Project Hub</a> • 
+    <a href="signoz_dashboard_live.html">Live Dashboard</a> • 
+    <a href="SYSTEM_ARCHITECTURE_DIAGRAM.html">Architecture</a>
+  </p>
+</div>
+
+<script>
+  // ===== State Management =====
+  let chart;
+  let eventCount = 0;
+  let errorCount = 0;
+  let activeTests = 0;
+  let metricsHistory = [];
+  
+  const metricsData = {
+    labels: [],
+    datasets: [{
+      label: 'Throughput (req/sec)',
+      data: [],
+      borderColor: '#7c5cff',
+      backgroundColor: 'rgba(124,92,255,0.2)',
+      tension: 0.4,
+      fill: true
+    }]
+  };
+  
+  // ===== Chart Initialization =====
+  function initChart() {
+    const ctx = document.getElementById('metricsChart').getContext('2d');
+    chart = new Chart(ctx, {
+      type: 'line',
+      data: metricsData,
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: true, labels: { color: '#e9edf7' } },
+          tooltip: { mode: 'index', intersect: false }
+        },
+        scales: {
+          x: { display: false },
+          y: {
+            beginAtZero: true,
+            grid: { color: 'rgba(255,255,255,0.05)' },
+            ticks: { color: '#77809a' }
+          }
+        }
+      }
+    });
+  }
+  
+  // ===== Metrics Update =====
+  function updateMetrics(type) {
+    const time = new Date().toLocaleTimeString();
+    let value;
+    
+    switch(type) {
+      case 'laminar':
+        value = Math.floor(Math.random() * 50 + 400); // 400-450 steady
+        break;
+      case 'chaotic':
+        value = Math.floor(Math.random() * 400 + 300); // 300-700 volatile
+        break;
+      case 'canary':
+        value = Math.floor(Math.random() * 30 + 100); // 100-130 low
+        break;
+      case 'test':
+      default:
+        value = Math.floor(Math.random() * 100 + 200); // 200-300 test
+        break;
+    }
+    
+    metricsData.labels.push(time);
+    metricsData.datasets[0].data.push(value);
+    
+    if (metricsData.labels.length > 30) {
+      metricsData.labels.shift();
+      metricsData.datasets[0].data.shift();
+    }
+    
+    chart.update();
+    
+    // Update KPI cards
+    document.getElementById('throughput').textContent = value;
+    document.getElementById('totalEvents').textContent = ++eventCount;
+    document.getElementById('errorRate').textContent = 
+      eventCount > 0 ? ((errorCount / eventCount) * 100).toFixed(1) + '%' : '0%';
+  }
+  
+  // ===== Log Management =====
+  function addLog(level, source, message, details = '') {
+    const tbody = document.getElementById('logsBody');
+    
+    // Remove placeholder if exists
+    if (tbody.children.length === 1 && tbody.children[0].cells.length === 1) {
+      tbody.innerHTML = '';
+    }
+    
+    const row = document.createElement('tr');
+    const timestamp = new Date().toISOString().slice(0, 19).replace('T', ' ');
+    
+    row.innerHTML = `
+      <td style="font-family: 'Courier New', monospace; font-size: 12px; color: var(--muted);">${timestamp}</td>
+      <td><span class="log-level ${level}">${level}</span></td>
+      <td>${source}</td>
+      <td>${message}</td>
+      <td style="font-size: 12px; color: var(--muted);">${details}</td>
+    `;
+    
+    tbody.insertBefore(row, tbody.firstChild);
+    
+    // Keep only last 100 logs
+    while (tbody.children.length > 100) {
+      tbody.removeChild(tbody.lastChild);
+    }
+    
+    if (level === 'ERROR') errorCount++;
+  }
+  
+  // ===== Data Generation =====
+  function generateData(type) {
+    updateMetrics(type);
+    activeTests++;
+    document.getElementById('activeTests').textContent = activeTests;
+    
+    switch(type) {
+      case 'laminar':
+        addLog('INFO', 'Laminar', 'Laminar flow operational', 'Steady-state throughput 400-450 req/sec');
+        break;
+      case 'chaotic':
+        addLog('WARN', 'Chaotic', 'Turbulence detected', 'Volatile throughput 300-700 req/sec');
+        break;
+      case 'canary':
+        addLog('INFO', 'Canary', 'Canary test initiated', `ID: canary-${Date.now().toString(36)}`);
+        break;
+      case 'test':
+        addLog('DEBUG', 'Test', 'Test signal generated', 'Baseline throughput 200-300 req/sec');
+        break;
+    }
+    
+    updateTimestamp();
+    setTimeout(() => {
+      activeTests = Math.max(0, activeTests - 1);
+      document.getElementById('activeTests').textContent = activeTests;
+    }, 2000);
+  }
+  
+  // ===== Chaos Engineering =====
+  function runChaos(scenario) {
+    addLog('WARN', 'Chaos', `Chaos scenario: ${scenario}`, 'Simulated failure condition');
+    
+    // Simulate chaos effects on metrics
+    for (let i = 0; i < 5; i++) {
+      setTimeout(() => {
+        updateMetrics('chaotic');
+      }, i * 1000);
+    }
+    
+    // Add specific chaos logs
+    setTimeout(() => {
+      switch(scenario) {
+        case 'network-delay':
+          addLog('ERROR', 'Network', 'Request timeout after 500ms', 'Service: otel-collector');
+          break;
+        case 'service-down':
+          addLog('ERROR', 'Service', 'Connection refused', 'Target: http://localhost:8080');
+          break;
+        case 'memory-spike':
+          addLog('WARN', 'Memory', 'Memory usage: 87%', 'Threshold exceeded');
+          break;
+        case 'cpu-throttle':
+          addLog('WARN', 'CPU', 'CPU usage: 94%', 'Throttling detected');
+          break;
+        case 'disk-full':
+          addLog('ERROR', 'Disk', 'Disk space: 98% full', 'Write operations blocked');
+          break;
+        case 'packet-loss':
+          addLog('WARN', 'Network', 'Packet loss: 12%', 'Retransmission required');
+          break;
+      }
+    }, 2000);
+    
+    updateTimestamp();
+  }
+  
+  // ===== Control Functions =====
+  function stopData() {
+    addLog('INFO', 'Control', 'Stop signal issued', 'Test harness halted by operator');
+    const statusBar = document.getElementById('statusBar');
+    statusBar.classList.remove('active');
+    statusBar.classList.add('stopped');
+    document.getElementById('statusText').textContent = 'Test Harness Stopped';
+    
+    setTimeout(() => {
+      statusBar.classList.remove('stopped');
+      statusBar.classList.add('active');
+      document.getElementById('statusText').textContent = 'Test Harness Active';
+    }, 3000);
+    
+    updateTimestamp();
+  }
+  
+  function clearLogs() {
+    const tbody = document.getElementById('logsBody');
+    tbody.innerHTML = `
+      <tr>
+        <td colspan="5" style="text-align: center; color: var(--muted); padding: 32px;">
+          Logs cleared. Click a button above to generate test data.
+        </td>
+      </tr>
+    `;
+    eventCount = 0;
+    errorCount = 0;
+    document.getElementById('totalEvents').textContent = '0';
+    document.getElementById('errorRate').textContent = '0%';
+    addLog('INFO', 'Control', 'Logs cleared by operator', '');
+    updateTimestamp();
+  }
+  
+  function updateTimestamp() {
+    document.getElementById('lastUpdate').textContent = new Date().toLocaleTimeString();
+  }
+  
+  // ===== Initialization =====
+  window.onload = () => {
+    initChart();
+    updateTimestamp();
+    setInterval(updateTimestamp, 1000);
+    
+    // Welcome message
+    addLog('INFO', 'System', 'Test harness initialized', 'BossCat OEM Certified');
+  };
+</script>
+
+</body>
+</html>
+

--- a/docs/status/REFERENCES_MAP.md
+++ b/docs/status/REFERENCES_MAP.md
@@ -1,7 +1,7 @@
 # 🗺️ Resonai [OTel] — Canonical References Map
 
-**Version:** 1.1  
-**Updated:** 2025-10-19  
+**Version:** 1.2  
+**Updated:** 2026-06-12  
 **Purpose:** Single source of truth for all working parts
 
 **What's New in v1.1:**
@@ -26,11 +26,17 @@
 ### 2. Persona & Governance
 **Immutable rules for merge discipline, budgets, and ECRR methodology**
 
-- **[The Art of ECRR (Manual)](../bosscat/misc/ART_OF_ECRR.md)**  
+- **[The Art of ECRR (Manual)](../BossCat/misc/ART_OF_ECRR.md)**  
   Paired-agent protocol, kill-switch, strict budgets
 
-- **[Agents & Hierarchy](../bosscat/misc/AGENTS.md)**  
-  Agent roles and ECRR methodology
+- **[BossCat Charter](../BossCat/CHARTER.md)**  
+  Canonical governance and agent hierarchy
+
+- **[Immutable Persona v1.1](../BossCat/IMMUTABLE_PERSONA_v1.1.md)**  
+  Merge discipline and executive voice
+
+- **[Repository Index (AGENTS.md)](../../AGENTS.md)**  
+  Canonical agent entry point
 
 ---
 
@@ -103,7 +109,7 @@ The root consolidation organized 177 files into domain-specific folders:
 - **Root Docs Consolidated:** 177
 - **Inventory Files:** 4 (complete)
 - **Registries:** 3 (operational)
-- **Last Updated:** 2025-10-19T13:00:00+00:00
+- **Last Updated:** 2026-06-12T13:00:00+00:00
 
 ---
 


### PR DESCRIPTION
## Summary
- Refresh root README (June 2026 status, OTLP ports, quick commands, governance links)
- Fix REFERENCES_MAP case-sensitive BossCat paths and add Charter/Persona/AGENTS
- Restore `docs/BossCat/data_room_enhanced.html` so Documentation Hub Data Room link works

## Test plan
- [x] All relative README links resolve on disk
- [ ] Hub quick link to Data Room loads locally
